### PR TITLE
L12: Fix typo and show multiple citations

### DIFF
--- a/en/lesson-12.md
+++ b/en/lesson-12.md
@@ -115,9 +115,12 @@ The basic structure of our input is as shown in this example.
 The mathematics showcase is from \citet{Graham1995}, whereas
 there is some chemistry in \citet{Thomas2008}.
 
-Some parenthetical citations: \citep{Graham1995}, \citep[p.~56]{Thomas2008}.
+Some parenthetical citations: \citep{Graham1995}
+and then \citep[p.~56]{Thomas2008}.
 
-\citep[See][pp.~45-48]{Graham1995}
+\citep[See][pp.~45--48]{Graham1995}
+
+Together \citep{Graham1995,Thomas2008}
 
 \bibliographystyle{plainnat}
 \bibliography{learnlatex}
@@ -152,12 +155,14 @@ some new commands for this.
 \begin{document}
 The mathematics showcase is from \autocite{Graham1995}.
 
-Some more complex citations: \parencite{Graham1995},
-\textcite{Thomas2008}, \citetitle{Graham1995}.
+Some more complex citations: \parencite{Graham1995} or
+\textcite{Thomas2008} or possibly \citetitle{Graham1995}.
 
 \autocite[56]{Thomas2008}
 
 \autocite[See][45-48]{Graham1995}
+
+Together \autocite{Thomas2008,Graham1995}
 
 \printbibliography
 \end{document}
@@ -170,7 +175,7 @@ all quite easy to guess.
 
 Again, short text before and after the citation can be inserted with
 the optional arguments. Note that the page numbers need not be prefixed
-with `p.~` or `pp.~` here, `biblatex` can automatically add the approriate
+with `p.~` or `pp.~` here, `biblatex` can automatically add the appropriate
 prefix.
 
 In `biblatex`, the reference style is picked when we load the package. Here,


### PR DESCRIPTION
* Typo 'approriate' -> 'appropriate' ... hrmpf

* Demonstrate multiple citations. To avoid any doubt add text between other `\cite` calls.