### PR TITLE
add ace editor

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -10,6 +10,10 @@ logo: learnlatex.png
 plugins:
   - jekyll-sitemap
 
+kramdown:
+    syntax_highlighter_opts:
+      disable: true
+
 latex: "<span>L<span style='font-variant: small-caps; vertical-align:.35ex;margin-left:-.15em;margin-right:-.05em;'>a</span>T<span style='text-transform:uppercase; vertical-align:-.4ex;margin-left:-.1em;'>e</span>X</span>"
 tex: "<span>T<span style='text-transform:uppercase; vertical-align:-.4ex;margin-left:-.1em;'>e</span>X</span>"
 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -9,6 +9,17 @@
     <link rel=icon href=/learnlatex-favicon.png>
     <link rel="stylesheet" href="{{ "/assets/css/style.css?v=" | append: site.github.build_revision | relative_url }}">
     {% if page.path contains "-" or page.path contains "help" %}
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.4.12/ace.min.js"></script>
+    <style type="text/css" media="screen">
+      .ace_editor {
+	  border: 1px solid lightgray;
+	  margin-bottom: 1px !important;
+	  width: 100%;
+      }
+      div.spacer {
+	  margin-top:16px;
+      }
+    </style>
     <script src="../scripts/runlatex.js"></script>
     <script src="includes/buttons.js"></script>
     <style> td code {white-space: nowrap}</style>

--- a/en/help.md
+++ b/en/help.md
@@ -29,11 +29,7 @@ Example text.
 
 The example is complete. However you may wish to edit it to make small
 changes, perhaps as part of an Exercise set at the end of the lesson.
-
-The <button style="padding:0 1px;font-size:90%">Edit</button> button enables editing within the page; this is
-marked by the removal of the LaTeX syntax highlighting and a green
-border added around the code block. Note that this is just a basic edit facility provided by your browser;
-there is no TeX specific editing help as found in typical editing systems that you would use with TeX.
+The editor being used is [ACE](https://ace.c9.io/).
 
 Whether or not the code block has been edited, there are three basic ways that you can run the example.
 
@@ -80,8 +76,8 @@ Whether or not the code block has been edited, there are three basic ways that y
 
 3. If you have a TeX system installed locally, then you may copy the
    example code off the page, either explicitly selecting it, or by
-   using the <button style="padding:0 1px;font-size:90%">Copy</button>
-   button.  This will place the code in your operating system
+   using select all keyboard shortcuts in the editor (ctrl-A Ctrl-C
+   in windows for exammple). This will place the code in your operating system
    clipboard so you can start a blank document using your local
    editor, and paste in the text.
 

--- a/scripts/runlatex.js
+++ b/scripts/runlatex.js
@@ -49,7 +49,7 @@ function llexamples() {
 	ace.config.set('basePath', 'https://cdnjs.cloudflare.com/ajax/libs/ace/1.4.12') ;
 	editor.setTheme("ace/theme/textmate");
 	editor.getSession().setMode("ace/mode/latex");
-	editor.setOption("minLines",5);
+	editor.setOption("minLines",2);
 	editor.setOption("maxLines",100);
 	editor.resize();
 	editors["pre" + i]=editor;


### PR DESCRIPTION
Pull request to replace the simple contentediable `<pre>` by instance of the [ACE Editor](https://ace.c9.io/)

This adds line numbers fixing issue  #59

Removes the rouge highlighting so removes the need for the edit and copy buttons, fixing issue #55 

handles pasting formatted text better, addressing issue #45 

Also provides better latex highlighting and editor features (environment folding, search replace, indenting etc) [see keyboard shortcuts](https://github.com/ajaxorg/ace/wiki/Default-Keyboard-Shortcuts)

