### PR TITLE
T1

### DIFF
--- a/de/help.md
+++ b/de/help.md
@@ -8,6 +8,7 @@ das in einer Seite wie dieser gezeigt wird:
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \begin{document}
 Example text.
 \end{document}

--- a/en/extra-01.md
+++ b/en/extra-01.md
@@ -18,6 +18,7 @@ The examples are taken from the package documentation unless otherwise noted.
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{mhchem}
 \begin{document}
 \ce{Hg^2+ ->[I-] HgI2 ->[I-] [Hg^{II}I4]^2-}
@@ -28,6 +29,7 @@ The examples are taken from the package documentation unless otherwise noted.
 ### [`forest`](https://texdoc.net/pkg/forest)
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{forest}
 \begin{document}
 \begin{forest}
@@ -49,6 +51,7 @@ The examples are taken from the package documentation unless otherwise noted.
 ### [`xskak`](https://texdoc.net/pkg/xskak)
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{xskak}
 \begin{document}
 \newchessgame
@@ -68,6 +71,7 @@ Position after 2.\,\xskakget{lan}
 
 ```latex
 \documentclass{memoir}
+\usepackage[T1]{fontenc}
 \begin{document}
 \settowidth{\versewidth}{Nay, nay, I leave thee not,
                                        thou goest too}
@@ -104,6 +108,7 @@ Today will I depart. \\*
 <!-- {% raw %} -->
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{tikz}
 \usetikzlibrary {perspective}
 
@@ -142,6 +147,7 @@ x
 <!-- {% raw %} -->
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{pgfplots}
 \pgfplotsset{width=7cm,compat=1.17}
 
@@ -172,6 +178,7 @@ x
 <!-- {% raw %} -->
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{musixtex}
 
 \begin{document}

--- a/en/help.md
+++ b/en/help.md
@@ -22,6 +22,7 @@ the page like this:
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \begin{document}
 Example text.
 \end{document}

--- a/en/language-01.md
+++ b/en/language-01.md
@@ -12,6 +12,7 @@ using US English patterns, but you can switch to UK ones using `babel`.
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage[UKenglish]{babel}
 \begin{document}
 Some text

--- a/en/lesson-03.md
+++ b/en/lesson-03.md
@@ -15,6 +15,7 @@ have set up LaTeX locally; this is a good chance to see how the different
 options work.
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 
 \begin{document}
 Hey world!
@@ -78,6 +79,7 @@ We can add comments to a LaTeX file by starting them with `%`; let's use
 that to show the structure:
 ```latex
 \documentclass[a4paper,12pt]{article} % The document class with options
+\usepackage[T1]{fontenc}
 % A comment in the preamble
 \begin{document}
 % This is a comment

--- a/en/lesson-03.md
+++ b/en/lesson-03.md
@@ -67,6 +67,8 @@ Here the body has two paragraphs (in LaTeX you separate paragraphs
 with one or more blank lines).
 Before `\begin{document}` is the *document preamble*,
 which has code to set up the document layout.
+The `\usepackage` command is described in a [later lesson](lesson-06)
+it is used in most examples on this site to set up the font encoding.
 
 LaTeX has other `\begin{...}` and `\end{...}` pairs; these are
 called *environments*.

--- a/en/lesson-04.md
+++ b/en/lesson-04.md
@@ -15,6 +15,7 @@ that's usually how things are emphasised.)
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \begin{document}
 Some text with \emph{emphasis and \emph{nested} content}.
 
@@ -43,6 +44,7 @@ document.
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \begin{document}
 Hey world!
 
@@ -92,6 +94,7 @@ There are two common types of list built in to LaTeX.
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \begin{document}
 
 Ordered

--- a/en/lesson-05.md
+++ b/en/lesson-05.md
@@ -43,6 +43,7 @@ a bit different
 
 ```latex
 \documentclass{letter}
+\usepackage[T1]{fontenc}
 \begin{document}
 
 \begin{letter}{Some Address\\Some Street\\Some City}
@@ -103,6 +104,7 @@ bundle and `memoir` affects the appearance of the document.
 
 ```latex
 \documentclass{article} % Change the class here
+\usepackage[T1]{fontenc}
 
 \begin{document}
 

--- a/en/lesson-06.md
+++ b/en/lesson-06.md
@@ -20,6 +20,7 @@ rules, so it's important to tell LaTeX which one to use. This is handled by the
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 
 %\usepackage[french]{babel}
 
@@ -50,6 +51,7 @@ specifically about margins.
 
 ```latex
 \documentclass{book}
+\usepackage[T1]{fontenc}
 \usepackage[margin=1in]{geometry}
 
 \begin{document}

--- a/en/lesson-07.md
+++ b/en/lesson-07.md
@@ -9,6 +9,7 @@ package, which adds the command `\includegraphics` to LaTeX.
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{graphicx}
 
 \begin{document}
@@ -42,6 +43,7 @@ ratio stays correct.
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{graphicx}
 
 \begin{document}
@@ -60,6 +62,7 @@ might want to do is to `clip` and `trim` an image.
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{graphicx}
 
 \begin{document}
@@ -78,6 +81,7 @@ not leave large gaps in the page.
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{graphicx}
 \usepackage{lipsum}  % produce dummy text as filler
 

--- a/en/lesson-08.md
+++ b/en/lesson-08.md
@@ -67,6 +67,7 @@ source.
 <!-- {% raw %} -->
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{array}
 
 \begin{document}
@@ -86,6 +87,7 @@ right with only `l`, `c`, and `r`. See what happens in the following example:
 <!-- {% raw %} -->
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{array}
 
 \begin{document}
@@ -113,6 +115,7 @@ time. Compare the above outcome to the following:
 <!-- {% raw %} -->
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{array}
 
 \begin{document}
@@ -139,6 +142,7 @@ table of this lesson with the newly learned syntax:
 <!-- {% raw %} -->
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{array}
 
 \begin{document}
@@ -169,6 +173,7 @@ Three of the rule commands are: `\toprule`, `\midrule`, and
 <!-- {% raw %} -->
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{array}
 \usepackage{booktabs}
 
@@ -196,6 +201,7 @@ column you need to specify that as a range (with both numbers matching).
 <!-- {% raw %} -->
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{array}
 \usepackage{booktabs}
 
@@ -222,6 +228,7 @@ with an optional argument enclosed in parentheses:
 <!-- {% raw %} -->
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{array}
 \usepackage{booktabs}
 
@@ -253,6 +260,7 @@ case you can use `\addlinespace` to insert a small skip.
 <!-- {% raw %} -->
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{array}
 \usepackage{booktabs}
 
@@ -292,6 +300,7 @@ single column type_.
 <!-- {% raw %} -->
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{array}
 \usepackage{booktabs}
 
@@ -320,6 +329,7 @@ table's head row:
 <!-- {% raw %} -->
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{array}
 \usepackage{booktabs}
 
@@ -346,6 +356,7 @@ correct idea of what was meant without explicitly making cells span rows.
 <!-- {% raw %} -->
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{array}
 \usepackage{booktabs}
 

--- a/en/lesson-09.md
+++ b/en/lesson-09.md
@@ -11,6 +11,7 @@ in your document you have to label it, and then in other places, you refer to it
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 
 \begin{document}
 Hey world!

--- a/en/lesson-10.md
+++ b/en/lesson-10.md
@@ -11,6 +11,7 @@ and display.
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \begin{document}
 A sentence with inline mathematics: $y = mx + c$.
 A second sentence with inline mathematics: $5^{2}=3^{2}+4^{2}$.
@@ -57,6 +58,7 @@ We can easily add superscripts and subscripts; these are marked using `^` and
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \begin{document}
 Superscripts $a^{b}$ and subscripts $a_{b}$.
 \end{document}
@@ -72,6 +74,7 @@ Greek letter.
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \begin{document}
 Some mathematics: $y = 2 \sin \theta^{2}$.
 \end{document}
@@ -103,6 +106,7 @@ It's particularly useful for integrations, for example:
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \begin{document}
 A paragraph about a larger equation
 \[
@@ -122,6 +126,7 @@ environment. Let's try the same example again:
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \begin{document}
 A paragraph about a larger equation
 \begin{equation}
@@ -147,6 +152,7 @@ contains many more examples than we can show in this lesson.
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{amsmath}
 
 \begin{document}
@@ -172,6 +178,7 @@ example for matrices.
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{amsmath}
 \begin{document}
 AMS matrices.
@@ -213,6 +220,7 @@ write a matrix as
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \begin{document}
 The matrix $\mathbf{M}$.
 \end{document}
@@ -229,6 +237,7 @@ specific font styles such as `\textrm{..}`.
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{amsmath}
 \begin{document}
 

--- a/en/lesson-11.md
+++ b/en/lesson-11.md
@@ -13,6 +13,7 @@ package.
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage[parfill]{parskip}
 \usepackage{lipsum} % Just for some filler text
 \begin{document}
@@ -48,6 +49,7 @@ for that.
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \begin{document}
 Some text \hspace{1cm} more text.
 
@@ -69,6 +71,7 @@ For short bits of text, we use `\textbf`, `\textit`, `\textrm`, `\textsf`,
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \begin{document}
 Let's have some font fun: \textbf{bold}, \textit{italic}, \textrm{roman},
 \textsf{sans serif}, \texttt{monospaced} and \textsc{small caps}.
@@ -83,6 +86,7 @@ or we can use `{...}` to make an explicit group.
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \begin{document}
 Normal text.
 
@@ -104,6 +108,7 @@ _before_ changing the font size back; see how we add an explicit `\par`
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \begin{document}
 Normal text.
 

--- a/en/lesson-12.md
+++ b/en/lesson-12.md
@@ -114,6 +114,7 @@ The basic structure of our input is as shown in this example.
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{natbib}
 
 \begin{document}
@@ -154,6 +155,7 @@ some new commands for this.
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage[style=authoryear]{biblatex}
 \addbibresource{learnlatex.bib} % file of reference info
 

--- a/en/lesson-13.md
+++ b/en/lesson-13.md
@@ -38,6 +38,7 @@ A longer document might therefore look something like the following:
 <!-- pre0 {% raw %} -->
 ```latex
 \documentclass{book}
+\usepackage[T1]{fontenc}
 \usepackage{biblatex}
 \addbibresource{biblatex-examples.bib}
 

--- a/en/lesson-14.md
+++ b/en/lesson-14.md
@@ -75,6 +75,7 @@ an example showing some Latin and Greek letters as well as some CJK ideographs:
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{fontspec}
 \setmainfont{texgyretermes-regular.otf}
 \newfontfamily\cjkfont{FandolSong-Regular.otf}

--- a/en/lesson-14.md
+++ b/en/lesson-14.md
@@ -75,7 +75,6 @@ an example showing some Latin and Greek letters as well as some CJK ideographs:
 
 ```latex
 \documentclass{article}
-\usepackage[T1]{fontenc}
 \usepackage{fontspec}
 \setmainfont{texgyretermes-regular.otf}
 \newfontfamily\cjkfont{FandolSong-Regular.otf}

--- a/en/lesson-15.md
+++ b/en/lesson-15.md
@@ -46,6 +46,7 @@ TeX Live or MiKTeX.
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 
 \newcommand\mycommand{\textbold{hmmm}}
 
@@ -62,7 +63,7 @@ This produces a multi-line message in the log file.
 ! Undefined control sequence.
 \mycommand ->\textbold 
                        {hmmm}
-l.7 My command is used here \mycommand
+l.8 My command is used here \mycommand
                                       .
 ? 
 ```
@@ -104,6 +105,7 @@ as it makes it appear that `\mycommand` is not defined.
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 
 \usepackage[leqno}{amsmath}
 
@@ -126,7 +128,7 @@ lines do accurately display the location of the error by the use of
 the linebreak showing how far TeX had read:
 
 ```
-l.3 \usepackage[leqno}
+l.4 \usepackage[leqno}
                       {amsmath}
 ```
 {: .noedit :}
@@ -136,6 +138,7 @@ l.3 \usepackage[leqno}
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 
 \usepackage{amsmathz}
 

--- a/en/lesson-16.md
+++ b/en/lesson-16.md
@@ -81,6 +81,7 @@ How do you construct a MWE? Normally easiest is to start from
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \begin{document}
 Text
 \end{document}

--- a/en/more-04.md
+++ b/en/more-04.md
@@ -9,6 +9,7 @@ to set up 'meta-data' and one to use it.
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \begin{document}
 \author{A.~N.~Other \and D.~Nobacon}
 \title{Some things I did}
@@ -38,6 +39,7 @@ another one, less common: the "descriptive lists".
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \begin{document}
 
 \begin{description}

--- a/en/more-05.md
+++ b/en/more-05.md
@@ -22,6 +22,7 @@ give you an example of how it works:
 
 ```latex
 \documentclass{beamer}
+\usepackage[T1]{fontenc}
 \begin{document}
 
 \begin{frame}{A first frame}
@@ -56,6 +57,7 @@ class. It automatically sets the size of the page to surround the printed conten
 
 ```latex
 \documentclass{standalone}
+\usepackage[T1]{fontenc}
 \begin{document}
 A simple document: this will be a very small box!
 \end{document}

--- a/en/more-06.md
+++ b/en/more-06.md
@@ -20,6 +20,7 @@ a German keyboard.
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 
 \usepackage[ngerman]{babel} % Notice that the option name is 'ngerman'
 
@@ -43,6 +44,7 @@ we might use:
 
 ```latex
 \documentclass[ngerman]{article} % Notice that the option name is 'ngerman'
+\usepackage[T1]{fontenc}
 
 \usepackage{babel}
 

--- a/en/more-07.md
+++ b/en/more-07.md
@@ -66,6 +66,7 @@ The `float` package will do that.
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{graphicx}
 \usepackage{lipsum}  % dummy text for filler
 \usepackage{float}
@@ -99,6 +100,7 @@ command, `\trivfloat`, to make new types of float.
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{graphicx}
 \usepackage{lipsum}  % dummy text for filler
 \usepackage{trivfloat}

--- a/en/more-08.md
+++ b/en/more-08.md
@@ -23,6 +23,7 @@ colon after it, you can do the following:
 <!-- {% raw %} -->
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{array}
 \usepackage{booktabs}
 
@@ -51,6 +52,7 @@ it can be used to change a single cell's alignment as shown below.
 <!-- {% raw %} -->
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{array}
 \usepackage{booktabs}
 
@@ -79,6 +81,7 @@ each column. You can adjust this space to any length using `\setlength`:
 <!-- {% raw %} -->
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{array}
 
 \setlength\tabcolsep{1cm}
@@ -101,6 +104,7 @@ between the columns you specify as an argument:
 <!-- {% raw %} -->
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{array}
 
 \begin{document}
@@ -123,6 +127,7 @@ _adds_ its argument in center of the space between two columns.
 <!-- {% raw %} -->
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{array}
 
 \begin{document}
@@ -144,6 +149,7 @@ Sometimes you have to use vertical rules.
 <!-- {% raw %} -->
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{array}
 
 \begin{document}
@@ -175,6 +181,7 @@ braces after `r` or `l`.
 <!-- {% raw %} -->
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{array}
 \usepackage{booktabs}
 
@@ -199,6 +206,7 @@ A simple example with two aligned numeric columns would be:
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{booktabs}
 \usepackage{siunitx}
 \begin{document}
@@ -245,6 +253,7 @@ as necessary.
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{array}
 \begin{document}
 
@@ -288,6 +297,7 @@ specification of `p{...}` for an automatically determined width.
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{tabularx}
 \begin{document}
 
@@ -386,6 +396,7 @@ for full details, but we show a simple example here.
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{array}
 \usepackage{threeparttable}
 \begin{document}
@@ -427,6 +438,7 @@ text size.
 
 ```latex
 \documentclass[a4paper]{article}
+\usepackage[T1]{fontenc}
 \usepackage{array}
 \usepackage{ragged2e}
 \begin{document}
@@ -480,6 +492,7 @@ a single row in which some cells are split vertically by the use of nested
 <!-- {% raw %} -->
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{array}
 \usepackage{booktabs}
 
@@ -504,6 +517,7 @@ bottom aligned respectively and is used like this:
 <!-- {% raw %} -->
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{array}
 \usepackage{booktabs}
 
@@ -543,6 +557,7 @@ The following example demonstrates the `\extrarowheight` parameter.
 
 ```latex
 \documentclass[a4paper]{article}
+\usepackage[T1]{fontenc}
 \usepackage{array}
 \begin{document}
 

--- a/en/more-09.md
+++ b/en/more-09.md
@@ -10,6 +10,7 @@ in the document preamble.
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage[hidelinks]{hyperref}
 \begin{document}
 

--- a/en/more-10.md
+++ b/en/more-10.md
@@ -14,6 +14,7 @@ form  omits the equation numbers by default.
 
 ```latex
 \documentclass[a4paper]{article}
+\usepackage[T1]{fontenc}
 
 \usepackage{amsmath}
 
@@ -43,6 +44,7 @@ shown, each aligned towards its relation symbol.
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{amsmath}
 \begin{document}
 Aligned equations
@@ -61,6 +63,7 @@ in `ed` that make a subterm of a larger display for example, `aligned` and
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{amsmath}
 \begin{document}
 Aligned:
@@ -84,6 +87,7 @@ compare the items in the list in the following example.
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{amsmath}
 \begin{document}
 \begin{itemize}
@@ -109,6 +113,7 @@ letters or words in upright bold roman.
 
 ```latex
 \documentclass[a4paper]{article}
+\usepackage[T1]{fontenc}
 
 \begin{document}
 
@@ -130,6 +135,7 @@ on `\pi` in the example above.)
 
 ```latex
 \documentclass[a4paper]{article}
+\usepackage[T1]{fontenc}
 \usepackage{bm}
 
 \begin{document}
@@ -149,6 +155,7 @@ features, such as variants of the `amsmath` matrix environments that
 allow the column alignment to be specified.
 ```latex
 \documentclass[a4paper]{article}
+\usepackage[T1]{fontenc}
 \usepackage{mathtools}
 
 \begin{document}

--- a/en/more-11.md
+++ b/en/more-11.md
@@ -12,6 +12,7 @@ handle this automatically.
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \begin{document}
 One small paragraph, which we have filled out a little to make sure you can
 see the effect here!

--- a/en/more-13.md
+++ b/en/more-13.md
@@ -15,6 +15,7 @@ instructions to LaTeX:
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{imakeidx}
 \makeindex
 \begin{document}

--- a/en/more-15.md
+++ b/en/more-15.md
@@ -11,6 +11,7 @@ main lesson, TeX's display of the error context should still pinpoint the error 
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 
 \usepackage{amsmath}
 
@@ -28,7 +29,7 @@ main lesson, TeX's display of the error context should still pinpoint the error 
 Here the error will be reported on line 11
 
 ```
-l.11 \end{align}
+l.12 \end{align}
 ```
 {: .noedit :}
 
@@ -57,6 +58,7 @@ always concentrate on fixing the first reported error.
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 
 \begin{document}
 Text_word  $\alpha + \beta$.
@@ -73,7 +75,7 @@ TeX does report this correctly with the _first_ error message
 ! Missing $ inserted.
 <inserted text> 
                 $
-l.4 Text_
+l.5 Text_
          word  $\alpha + \beta$.
 ?
 ```
@@ -88,7 +90,7 @@ then continues until the `$` which ends math, so the following
 ! Missing $ inserted.
 <inserted text> 
                 $
-l.4 Text_word  $\alpha
+l.5 Text_word  $\alpha
                        + \beta$.
 ? 
 ```
@@ -105,6 +107,7 @@ to see the error message in the log add `%!TeX log`.
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 
 \begin{document}
 

--- a/ja/help.md
+++ b/ja/help.md
@@ -31,6 +31,7 @@ English example:
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \begin{document}
 Example text.
 \end{document}

--- a/pt/extra-01.md
+++ b/pt/extra-01.md
@@ -20,6 +20,7 @@ contrário.
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{mhchem}
 \begin{document}
 \ce{Hg^2+ ->[I-] HgI2 ->[I-] [Hg^{II}I4]^2-}
@@ -30,6 +31,7 @@ contrário.
 ### [`forest`](https://texdoc.net/pkg/forest)
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{forest}
 \begin{document}
 \begin{forest}
@@ -51,6 +53,7 @@ contrário.
 ### [`xskak`](https://texdoc.net/pkg/xskak)
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{xskak}
 \begin{document}
 \newchessgame
@@ -70,6 +73,7 @@ Position after 2.\,\xskakget{lan}
 
 ```latex
 \documentclass{memoir}
+\usepackage[T1]{fontenc}
 \begin{document}
 \settowidth{\versewidth}{Nay, nay, I leave thee not,
                                        thou goest too}
@@ -106,6 +110,7 @@ Today will I depart. \\*
 <!-- {% raw %} -->
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{tikz}
 \usetikzlibrary {perspective}
 
@@ -144,6 +149,7 @@ x
 <!-- {% raw %} -->
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{pgfplots}
 \pgfplotsset{width=7cm,compat=1.17}
 
@@ -174,6 +180,7 @@ x
 <!-- {% raw %} -->
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{musixtex}
 
 \begin{document}

--- a/pt/help.md
+++ b/pt/help.md
@@ -21,6 +21,7 @@ Cada exemplo consiste de um documento LaTeX completo mostrado na página assim:
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \begin{document}
 Texto de exemplo.
 \end{document}

--- a/pt/language-01.md
+++ b/pt/language-01.md
@@ -15,6 +15,7 @@ respectivamente:
 
 ```latex
 \documentclass{book}
+\usepackage[T1]{fontenc}
 \usepackage[brazilian]{babel}
 \begin{document}
 \chapter{Viu? :)}

--- a/pt/lesson-03.md
+++ b/pt/lesson-03.md
@@ -15,6 +15,7 @@ chance de ver como as diferentes opções funcionam.
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 
 \begin{document}
 Olá mundo!
@@ -77,6 +78,7 @@ Podemos também adicionar comentários em um arquivo LaTeX prefixando-o com um
 `%`; vamos usar isso para mostrar a estrutura do documento:
 ```latex
 \documentclass[a4paper,12pt]{article} % The document class with options
+\usepackage[T1]{fontenc}
 % Um comentário no preâmbulo
 \begin{document}
 % Isto é um comentário

--- a/pt/lesson-04.md
+++ b/pt/lesson-04.md
@@ -15,6 +15,7 @@ texto em itálico (em impressões, geralmente é como texto é enfatizado).
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \begin{document}
 Texto com \emph{ênfase e com \emph{ênfase} aninhada}.
 
@@ -44,6 +45,7 @@ vertical, etc., e mantém o resultado uniforme ao longo do documento.
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \begin{document}
 Olá mundo!
 
@@ -93,6 +95,7 @@ Há dois tipos comuns de listas por padrão no LaTeX:
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \begin{document}
 
 Ordenada:

--- a/pt/lesson-05.md
+++ b/pt/lesson-05.md
@@ -44,6 +44,7 @@ os comandos disponíveis são um pouco diferentes:
 
 ```latex
 \documentclass{letter}
+\usepackage[T1]{fontenc}
 \begin{document}
 
 \begin{letter}{Um endereço\\Em uma rua\\de Alguma Cidade}
@@ -104,6 +105,7 @@ KOMA-Script, e `memoir` afeta a aparência do documento.
 
 ```latex
 \documentclass{article} % Mude a classe aqui
+\usepackage[T1]{fontenc}
 
 \begin{document}
 

--- a/pt/lesson-06.md
+++ b/pt/lesson-06.md
@@ -20,6 +20,7 @@ Isso é configurado pelo pacote `babel`.
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 
 %\usepackage[brazilian]{babel}
 
@@ -50,6 +51,7 @@ sobre margens.
 
 ```latex
 \documentclass{book}
+\usepackage[T1]{fontenc}
 \usepackage[margin=1in]{geometry}
 
 \begin{document}

--- a/pt/lesson-07.md
+++ b/pt/lesson-07.md
@@ -9,6 +9,7 @@ comando `\includegraphics` ao LaTeX:
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{graphicx}
 
 \begin{document}
@@ -42,6 +43,7 @@ automaticamente para que proporção fique correta.
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{graphicx}
 
 \begin{document}
@@ -61,6 +63,7 @@ girá-las usando `angle`.  Outra coisa que você pode querer fazer é cortar (co
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{graphicx}
 
 \begin{document}
@@ -79,6 +82,7 @@ para que elas não deixem grandes espaços em branco na página.
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{graphicx}
 \usepackage{lipsum}  % produzir texto de preenchimento
 

--- a/pt/lesson-08.md
+++ b/pt/lesson-08.md
@@ -66,6 +66,7 @@ entender o código da tabela.
 <!-- {% raw %} -->
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{array}
 
 \begin{document}
@@ -85,6 +86,7 @@ tabela apenas com `l`, `c`, e `r`.  Veja o que acontece no exemplo a seguir:
 <!-- {% raw %} -->
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{array}
 
 \begin{document}
@@ -111,6 +113,7 @@ Compare a tabela acima com a seguinte:
 <!-- {% raw %} -->
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{array}
 
 \begin{document}
@@ -136,6 +139,7 @@ a primeira tabela dessa lição, mas com a nova sintaxe:
 <!-- {% raw %} -->
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{array}
 
 \begin{document}
@@ -166,6 +170,7 @@ usados no topo, meio, e final da tabela, respectivamente:
 <!-- {% raw %} -->
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{array}
 \usepackage{booktabs}
 
@@ -194,6 +199,7 @@ nesse caso específico):
 <!-- {% raw %} -->
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{array}
 \usepackage{booktabs}
 
@@ -220,6 +226,7 @@ um dos lados com um argumento opcional entre parênteses:
 <!-- {% raw %} -->
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{array}
 \usepackage{booktabs}
 
@@ -252,6 +259,7 @@ vertical:
 <!-- {% raw %} -->
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{array}
 \usepackage{booktabs}
 
@@ -290,6 +298,7 @@ mas apenas _um único tipo de coluna_:
 <!-- {% raw %} -->
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{array}
 \usepackage{booktabs}
 
@@ -317,6 +326,7 @@ tabela:
 <!-- {% raw %} -->
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{array}
 \usepackage{booktabs}
 
@@ -343,6 +353,7 @@ explicitamente juntar as linhas:
 <!-- {% raw %} -->
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{array}
 \usepackage{booktabs}
 

--- a/pt/lesson-09.md
+++ b/pt/lesson-09.md
@@ -13,6 +13,7 @@ você pode referenciar esse rótulo.
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 
 \begin{document}
 Olá mundo!

--- a/pt/lesson-10.md
+++ b/pt/lesson-10.md
@@ -11,6 +11,7 @@ do modo matemático: linear (_inline_) e em exibição (_display_).
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \begin{document}
 Uma frase com matemática linear: $y = mx + c$.
 Uma segunda frase com matemática linear: $5^{2}=3^{2}+4^{2}$.
@@ -58,6 +59,7 @@ Podemos facilmente adicionar superscritos e subscritos; eles são marcados usand
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \begin{document}
 Superscritos $a^{b}$ e subscritos $a_{b}$.
 \end{document}
@@ -73,6 +75,7 @@ letra Grega:
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \begin{document}
 Matemática: $y = 2 \sin \theta^{2}$.
 \end{document}
@@ -102,6 +105,7 @@ exemplo:
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \begin{document}
 Um parágrafo sobre uma equação maior
 \[
@@ -125,6 +129,7 @@ environment. Let's try the same example again:
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \begin{document}
 Um parágrafo sobre uma equação maior
 \begin{equation}
@@ -148,6 +153,7 @@ contém muito mais exemplos do que podemos mostrar nessa lição.
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{amsmath}
 
 \begin{document}
@@ -173,6 +179,7 @@ matrizes:
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{amsmath}
 \begin{document}
 Matrizes AMS.
@@ -213,6 +220,7 @@ podemos escrever uma matriz como:
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \begin{document}
 A matriz $\mathbf{M}$.
 \end{document}
@@ -230,6 +238,7 @@ definido no pacote `amsmath`) ou estilos específicos de fonte, como
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{amsmath}
 \begin{document}
 

--- a/pt/lesson-11.md
+++ b/pt/lesson-11.md
@@ -11,6 +11,7 @@ Um estilo comum é não ter indentação para parágrafos, mas ter uma
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage[parfill]{parskip}
 \usepackage{lipsum} % Para texto de enchimento
 \begin{document}
@@ -46,6 +47,7 @@ para isso:
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \begin{document}
 Algum texto \hspace{1cm} mais texto.
 
@@ -67,6 +69,7 @@ Para trechos curtos, usamos `\textbf`, `\textit`, `\textrm`, `\textsf`,
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \begin{document}
 Vamos nos divertir com fontes: \textbf{negrito}, \textit{itálico}, \textrm{romano},
 \textsf{sans serif}, \texttt{monoespaçado} and \textsc{versalete}.
@@ -81,6 +84,7 @@ células de tabelas, ou podemos usar `{...}` para criar um grupo explícito:
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \begin{document}
 Texto normal.
 
@@ -102,6 +106,7 @@ adicionamos um `\par` (equivalente a uma linha em branco) aqui:
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \begin{document}
 Texto normal
 

--- a/pt/lesson-12.md
+++ b/pt/lesson-12.md
@@ -111,6 +111,7 @@ A estrutura básica do nosso documento é mostrada no exemplo:
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{natbib}
 
 \begin{document}
@@ -152,6 +153,7 @@ no corpo do documento.  Há alguns comandos novos para isso:
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage[style=authoryear]{biblatex}
 \addbibresource{learnlatex.bib} % file of reference info
 

--- a/pt/lesson-13.md
+++ b/pt/lesson-13.md
@@ -39,6 +39,7 @@ Um documento longo pode, então, ter essa aparência:
 <!-- pre0 {% raw %} -->
 ```latex
 \documentclass{book}
+\usepackage[T1]{fontenc}
 \usepackage{biblatex}
 \addbibresource{biblatex-examples.bib}
 

--- a/pt/lesson-14.md
+++ b/pt/lesson-14.md
@@ -76,7 +76,6 @@ letras do alfabeto Latino e Grego, assim como alguns ideogramas chineses:
 
 ```latex
 \documentclass{article}
-\usepackage[T1]{fontenc}
 \usepackage{fontspec}
 \setmainfont{texgyretermes-regular.otf}
 \newfontfamily\cjkfont{FandolSong-Regular.otf}

--- a/pt/lesson-14.md
+++ b/pt/lesson-14.md
@@ -76,6 +76,7 @@ letras do alfabeto Latino e Grego, assim como alguns ideogramas chineses:
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{fontspec}
 \setmainfont{texgyretermes-regular.otf}
 \newfontfamily\cjkfont{FandolSong-Regular.otf}

--- a/pt/lesson-15.md
+++ b/pt/lesson-15.md
@@ -42,6 +42,7 @@ TeXworks ou TeXShop mas não instalar um sistema TeX, como TeX Live ou MiKTeX.
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 
 \newcommand\mycommand{\textbold{hmmm}}
 
@@ -58,7 +59,7 @@ Esse documento produz uma mensagem de erro de várias linhas no log:
 ! Undefined control sequence.
 \mycommand ->\textbold 
                        {hmmm}
-l.7 My command is used here \mycommand
+l.8 My command is used here \mycommand
                                       .
 ? 
 ```
@@ -100,6 +101,7 @@ pois faz parecer que o comando `\mycommand` não está definido.
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 
 \usepackage[leqno}{amsmath}
 
@@ -122,7 +124,7 @@ precisamente o local do erro por usar uma quebra de linha mostrando até onde o
 TeX leu:
 
 ```
-l.3 \usepackage[leqno}
+l.4 \usepackage[leqno}
                       {amsmath}
 ```
 {: .noedit :}
@@ -131,6 +133,7 @@ l.3 \usepackage[leqno}
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 
 \usepackage{amsmathz}
 
@@ -155,6 +158,7 @@ sistema.
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 
 \begin{document}
 

--- a/pt/lesson-16.md
+++ b/pt/lesson-16.md
@@ -79,6 +79,7 @@ Como construir um MWE?  Normalmente o mais fácil é começar de:
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \begin{document}
 Text
 \end{document}

--- a/pt/more-04.md
+++ b/pt/more-04.md
@@ -9,6 +9,7 @@ configurar os 'meta dados', e um para usá-los:
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \begin{document}
 \author{U.~M.~Autor \and O.~Outro}
 \title{Algumas coisas que fiz}
@@ -39,6 +40,7 @@ outro tipo, menos comum: as "listas descritivas".
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \begin{document}
 
 \begin{description}

--- a/pt/more-05.md
+++ b/pt/more-05.md
@@ -22,6 +22,7 @@ funciona:
 
 ```latex
 \documentclass{beamer}
+\usepackage[T1]{fontenc}
 \begin{document}
 
 \begin{frame}{O primeiro quadro}
@@ -57,6 +58,7 @@ o tamanho da página para conter o conteúdo impresso:
 
 ```latex
 \documentclass{standalone}
+\usepackage[T1]{fontenc}
 \begin{document}
 Um documento simples:  esta será uma caixa bem pequena!
 \end{document}

--- a/pt/more-06.md
+++ b/pt/more-06.md
@@ -21,6 +21,7 @@ de digitar tremas sem ter uma tecla especial no teclado:
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 
 \usepackage[ngerman]{babel} % Note que o nome da opção é 'ngerman'
 
@@ -45,6 +46,7 @@ documento para todos os pacotes podemos usar:
 
 ```latex
 \documentclass[ngerman]{article} % Note que o nome da opção é 'ngerman'
+\usepackage[T1]{fontenc}
 
 \usepackage{babel}
 

--- a/pt/more-07.md
+++ b/pt/more-07.md
@@ -68,6 +68,7 @@ a figura colocada no PDF exatamente onde ela está no código fonte.  O pacote
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{graphicx}
 \usepackage{lipsum}  % texto de enchimento
 \usepackage{float}
@@ -101,6 +102,7 @@ inserido independentemente.  Você pode fazer isso usando o pacote
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{graphicx}
 \usepackage{lipsum}  % texto de enchimento
 \usepackage{trivfloat}

--- a/pt/more-08.md
+++ b/pt/more-08.md
@@ -24,6 +24,7 @@ seguinte:
 <!-- {% raw %} -->
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{array}
 \usepackage{booktabs}
 
@@ -52,6 +53,7 @@ ser usado para mudar o alinhamento de uma única célula, como mostrado abaixo:
 <!-- {% raw %} -->
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{array}
 \usepackage{booktabs}
 
@@ -81,6 +83,7 @@ ajustar esse espaço usando `\setlength`:
 <!-- {% raw %} -->
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{array}
 
 \setlength\tabcolsep{1cm}
@@ -102,6 +105,7 @@ vai remover o espaçamento entre duas colunas, e inserir o argumento entre elas:
 <!-- {% raw %} -->
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{array}
 
 \begin{document}
@@ -124,6 +128,7 @@ argumento no centro do espaço entre as colunas:
 <!-- {% raw %} -->
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{array}
 
 \begin{document}
@@ -144,6 +149,7 @@ argumento no centro do espaço entre as colunas:
 <!-- {% raw %} -->
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{array}
 
 \begin{document}
@@ -176,6 +182,7 @@ especificando um comprimento entre chaves depois de `r` ou `l`:
 <!-- {% raw %} -->
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{array}
 \usepackage{booktabs}
 
@@ -200,6 +207,7 @@ Um exemplo simples, com duas colunas numéricas alinhadas é:
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{booktabs}
 \usepackage{siunitx}
 \begin{document}
@@ -247,6 +255,7 @@ partir daquele ponto no preâmbulo.  `\extracolsep` é quase sempre usado com
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{array}
 \begin{document}
 
@@ -289,6 +298,7 @@ um valor automaticamente determinado para a largura.
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{tabularx}
 \begin{document}
 
@@ -389,6 +399,7 @@ aqui:
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{array}
 \usepackage{threeparttable}
 \begin{document}
@@ -430,6 +441,7 @@ para que as colunas não sejam tão estreitas em relação ao tamanho da fonte.
 
 ```latex
 \documentclass[a4paper]{article}
+\usepackage[T1]{fontenc}
 \usepackage{array}
 \usepackage{ragged2e}
 \begin{document}
@@ -481,6 +493,7 @@ ambientes `tabular` dentro dessa célula:
 <!-- {% raw %} -->
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{array}
 \usepackage{booktabs}
 
@@ -505,6 +518,7 @@ ao centro, ou ao fundo, respectivamente, e é usado assim:
 <!-- {% raw %} -->
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{array}
 \usepackage{booktabs}
 
@@ -541,6 +555,7 @@ O exemplo a seguir demonstra o parâmetro `\extrarowheight`:
 
 ```latex
 \documentclass[a4paper]{article}
+\usepackage[T1]{fontenc}
 \usepackage{array}
 \begin{document}
 

--- a/pt/more-09.md
+++ b/pt/more-09.md
@@ -10,6 +10,7 @@ pacotes especificados no preâmbulo do documento.
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage[hidelinks]{hyperref}
 \begin{document}
 

--- a/pt/more-10.md
+++ b/pt/more-10.md
@@ -20,6 +20,7 @@ form  omits the equation numbers by default.
 
 ```latex
 \documentclass[a4paper]{article}
+\usepackage[T1]{fontenc}
 
 \usepackage{amsmath}
 
@@ -49,6 +50,7 @@ alinhada em direção ao seu símbolo de relação
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{amsmath}
 \begin{document}
 Equações alinhadas
@@ -65,6 +67,7 @@ formam um sub termo de uma equação maior, por exemplo `aligned` e `gathered`:
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{amsmath}
 \begin{document}
 Aligned:
@@ -88,6 +91,7 @@ linha;  compare os itens na lista no exemplo a seguir:
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{amsmath}
 \begin{document}
 \begin{itemize}
@@ -114,6 +118,7 @@ individuais ou palavras em fonte romana em negrito.
 
 ```latex
 \documentclass[a4paper]{article}
+\usepackage[T1]{fontenc}
 
 \begin{document}
 
@@ -134,6 +139,7 @@ dentro de uma expressão normal, então você pode usar o comando `\bm` do pacot
 
 ```latex
 \documentclass[a4paper]{article}
+\usepackage[T1]{fontenc}
 \usepackage{bm}
 
 \begin{document}
@@ -155,6 +161,7 @@ que permitem escolher o alinhamento das colunas:
 
 ```latex
 \documentclass[a4paper]{article}
+\usepackage[T1]{fontenc}
 \usepackage{mathtools}
 
 \begin{document}

--- a/pt/more-11.md
+++ b/pt/more-11.md
@@ -10,6 +10,7 @@ deve deixar o LaTeX cuidar disso automaticamente.
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \begin{document}
 Um pequeno parágrafo, que nós alongamos para ter certeza que você
 consiga ver o efeito aqui!

--- a/pt/more-13.md
+++ b/pt/more-13.md
@@ -16,6 +16,7 @@ para o LaTeX:
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{imakeidx}
 \makeindex
 \begin{document}

--- a/pt/more-15.md
+++ b/pt/more-15.md
@@ -12,6 +12,7 @@ mostrado pelo TeX ainda deve mostrar a localização exata do erro.
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 
 \usepackage{amsmath}
 
@@ -29,7 +30,7 @@ mostrado pelo TeX ainda deve mostrar a localização exata do erro.
 Aqui o erro será relatado na linha 11:
 
 ```
-l.11 \end{align}
+l.12 \end{align}
 ```
 {: .noedit :}
 
@@ -57,6 +58,7 @@ em corrigir o _primeiro_ erro.
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 
 \begin{document}
 Text_word  $\alpha + \beta$.
@@ -73,7 +75,7 @@ O TeX relata esse corretamente com a _primeira_ mensagem de erro:
 ! Missing $ inserted.
 <inserted text> 
                 $
-l.4 Text_
+l.5 Text_
          word  $\alpha + \beta$.
 ?
 ```
@@ -88,7 +90,7 @@ o encerre, então o `\alpha` é visto em modo de texto causando outro erro:
 ! Missing $ inserted.
 <inserted text> 
                 $
-l.4 Text_word  $\alpha
+l.5 Text_word  $\alpha
                        + \beta$.
 ? 
 ```
@@ -106,6 +108,7 @@ mensagem de erro;  para ver a mensagem no log adicione `%!TeX log` no exemplo:
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 
 \begin{document}
 

--- a/vi/extra-01.md
+++ b/vi/extra-01.md
@@ -19,6 +19,7 @@ ví dụ cho thấy những công dụng phong phú mà LaTeX có thể cung c�
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{mhchem}
 \begin{document}
 \ce{Hg^2+ ->[I-] HgI2 ->[I-] [Hg^{II}I4]^2-}
@@ -29,6 +30,7 @@ ví dụ cho thấy những công dụng phong phú mà LaTeX có thể cung c�
 ### [`forest`](https://texdoc.net/pkg/forest)
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{forest}
 \begin{document}
 \begin{forest}
@@ -50,6 +52,7 @@ ví dụ cho thấy những công dụng phong phú mà LaTeX có thể cung c�
 ### [`xskak`](https://texdoc.net/pkg/xskak)
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{xskak}
 \begin{document}
 \newchessgame
@@ -69,6 +72,7 @@ Position after 2.\,\xskakget{lan}
 
 ```latex
 \documentclass{memoir}
+\usepackage[T1]{fontenc}
 \begin{document}
 \settowidth{\versewidth}{Nay, nay, I leave thee not,
                                        thou goest too}
@@ -105,6 +109,7 @@ Today will I depart. \\*
 <!-- {% raw %} -->
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{tikz}
 \usetikzlibrary {perspective}
 
@@ -143,6 +148,7 @@ x
 <!-- {% raw %} -->
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{pgfplots}
 \pgfplotsset{width=7cm,compat=1.17}
 
@@ -173,6 +179,7 @@ x
 <!-- {% raw %} -->
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{musixtex}
 
 \begin{document}

--- a/vi/help.md
+++ b/vi/help.md
@@ -17,6 +17,7 @@ Mỗi ví dụ bao gồm một tệp LaTeX nhỏ được hiển thị như sau:
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \begin{document}
 Example text.
 \end{document}

--- a/vi/lesson-03.md
+++ b/vi/lesson-03.md
@@ -18,6 +18,7 @@ Chú ý rằng ta sẽ dùng tiếng Anh cho các ví dụ ở đây. Cách dùn
 LaTeX sẽ được nói tới trong [một bài khác](language-01).
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 
 \begin{document}
 Hey world!
@@ -77,6 +78,7 @@ Ta có thể thêm ghi chú vào mã nguồn bằng cách bắt đầu chúng b�
 cùng thử nó xem:
 ```latex
 \documentclass[a4paper,12pt]{article} % Lớp văn bản với một số tùy chọn
+\usepackage[T1]{fontenc}
 % Một ghi chú ở phần khai báo
 \begin{document}
 % Đây là một ghi chú nữa

--- a/vi/lesson-04.md
+++ b/vi/lesson-04.md
@@ -16,6 +16,7 @@ bản.)
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \begin{document}
 Some text with \emph{emphasis and \emph{nested} content}.
 
@@ -47,6 +48,7 @@ v.v... đều được LaTeX lo.
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \begin{document}
 Hey world!
 
@@ -97,6 +99,7 @@ hai loại danh sách chính có sẵn trong LaTeX:
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \begin{document}
 
 Ordered % Có đánh số

--- a/vi/lesson-05.md
+++ b/vi/lesson-05.md
@@ -43,6 +43,7 @@ thấy. Khi viết bằng `letter`, các câu lệnh có hơi khác một chút
 
 ```latex
 \documentclass{letter}
+\usepackage[T1]{fontenc}
 \begin{document}
 
 \begin{letter}{Some Address\\Some Street\\Some City}
@@ -103,6 +104,7 @@ KOMA-script và `memoir` ảnh hưởng đến output như thế nào.
 
 ```latex
 \documentclass{article} % Thay đổi lớp văn bản ở đây
+\usepackage[T1]{fontenc}
 
 \begin{document}
 

--- a/vi/lesson-06.md
+++ b/vi/lesson-06.md
@@ -20,6 +20,7 @@ cần dùng ngôn ngữ nào. Điều này được xử lý bởi gói `babel`.
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 
 %\usepackage[french]{babel}
 
@@ -52,6 +53,7 @@ một ví dụ dành riêng cho việc thay đổi kích thước lề.
 
 ```latex
 \documentclass{book}
+\usepackage[T1]{fontenc}
 \usepackage[margin=1in]{geometry}
 
 \begin{document}

--- a/vi/lesson-07.md
+++ b/vi/lesson-07.md
@@ -9,6 +9,7 @@ lệnh `\includegraphics` vào LaTeX.
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{graphicx}
 
 \begin{document}
@@ -43,6 +44,7 @@ theo `\textwidth` (độ rộng của phần chữ trong trang giấy) hay `\tex
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{graphicx}
 
 \begin{document}
@@ -61,6 +63,7 @@ thứ khác bạn có thể muốn làm đó là cắt hình ảnh bằng `clip`
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{graphicx}
 
 \begin{document}
@@ -79,6 +82,7 @@ phần linh động để chúng không tạo ra khoảng trắng quá lớn tro
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{graphicx}
 \usepackage{lipsum}
 

--- a/vi/lesson-08.md
+++ b/vi/lesson-08.md
@@ -65,6 +65,7 @@ trong LaTeX, nhưng nó giúp việc đọc mã nguồn dễ dàng hơn.
 <!-- {% raw %} -->
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{array}
 
 \begin{document}
@@ -84,6 +85,7 @@ Nếu một cột có nội dung dài bạn sẽ gặp một số vấn đề n�
 <!-- {% raw %} -->
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{array}
 
 \begin{document}
@@ -110,6 +112,7 @@ sánh ví dụ trên với ví dụ dưới đây:
 <!-- {% raw %} -->
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{array}
 
 \begin{document}
@@ -136,6 +139,7 @@ này. Theo bảng trên, `*{6}{c}` tương đương với `cccccc`. Để cho th
 <!-- {% raw %} -->
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{array}
 
 \begin{document}
@@ -167,6 +171,7 @@ bảng).
 <!-- {% raw %} -->
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{array}
 \usepackage{booktabs}
 
@@ -193,6 +198,7 @@ vẽ đường kẻ ngang cho một cột duy nhất bạn vẫn phải viết t
 <!-- {% raw %} -->
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{array}
 \usepackage{booktabs}
 
@@ -219,6 +225,7 @@ vẽ đường kẻ ngang cho một cột duy nhất bạn vẫn phải viết t
 <!-- {% raw %} -->
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{array}
 \usepackage{booktabs}
 
@@ -249,6 +256,7 @@ giữa hai hàng. Ta có thể dùng `\addlinespace` cho việc đó.
 <!-- {% raw %} -->
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{array}
 \usepackage{booktabs}
 
@@ -286,6 +294,7 @@ _một_ ký tự kiểu cột duy nhất.
 <!-- {% raw %} -->
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{array}
 \usepackage{booktabs}
 
@@ -311,6 +320,7 @@ riêng ô đó. Ví dụ sau dùng cách này để căn giữa hàng trên cùn
 <!-- {% raw %} -->
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{array}
 \usepackage{booktabs}
 
@@ -336,6 +346,7 @@ thật sự gộp các ô trong cột.
 <!-- {% raw %} -->
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{array}
 \usepackage{booktabs}
 

--- a/vi/lesson-09.md
+++ b/vi/lesson-09.md
@@ -12,6 +12,7 @@ trí khác, ta tạo tham chiếu đén vị trí đánh dấu này.
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 
 \begin{document}
 Hey world!

--- a/vi/lesson-10.md
+++ b/vi/lesson-10.md
@@ -12,6 +12,7 @@ có một dòng riêng cho nó.
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \begin{document}
 A sentence with inline mathematics: $y = mx + c$. % Inline
 
@@ -50,6 +51,7 @@ này được đánh dấu bằng `^` và `_` tương ứng.
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \begin{document}
 Superscripts $a^{b}$ and subscripts $a_{b}$.
 \end{document}
@@ -64,6 +66,7 @@ Có *rất nhiều* các câu lệnh toán học. Một vài lệnh khá đơn g
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \begin{document}
 Some mathematics: $y = 2 \sin \theta^{2}$.
 \end{document}
@@ -91,6 +94,7 @@ gói `amsmath` (sẽ được nói tới sau).
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \begin{document}
 A paragraph about a larger equation
 \[
@@ -108,6 +112,7 @@ môi trường `equation`.
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \begin{document}
 A paragraph about a larger equation
 \begin{equation}
@@ -133,6 +138,7 @@ trong khóa này.
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{amsmath}
 
 \begin{document}
@@ -157,6 +163,7 @@ Ngoài ra gói còn cung cấp các môi trường để hỗ trợ việc viế
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{amsmath}
 \begin{document}
 AMS matrices.
@@ -198,6 +205,7 @@ một ma trận theo cách sau:
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \begin{document}
 The matrix $\mathbf{M}$.
 \end{document}
@@ -213,6 +221,7 @@ khi ta muốn thêm một vài từ theo font bình thường, khi đó ta có t
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{amsmath}
 \begin{document}
 $\text{bad use } size  \neq \mathit{size} \neq \mathrm{size} $

--- a/vi/lesson-11.md
+++ b/vi/lesson-11.md
@@ -11,6 +11,7 @@ muốn lùi đầu dòng mà muốn có một khoảng trống nhỏ giữa các
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage[parfill]{parskip}
 \usepackage{lipsum}
 \begin{document}
@@ -45,6 +46,7 @@ chiều ngang) và `\vspace` (khoảng trống theo chiều dọc).
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \begin{document}
 Some text \hspace{1cm} more text.
 
@@ -68,6 +70,7 @@ monospace) và `\textsc` (chữ theo font small-caps).
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \begin{document}
 Let's have some font fun: \textbf{bold}, \textit{italic}, \textrm{roman},
 \textsf{sans serif}, \texttt{monospaced} and \textsc{small caps}.
@@ -82,6 +85,7 @@ LaTeX đều là các nhóm khác nhau; mỗi ô bảng cũng là một nhóm; h
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \begin{document}
 Normal text.
 
@@ -106,6 +110,7 @@ cỡ chữ lại như bình thường &ndash; bạn có thể xem lệnh `\par` 
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \begin{document}
 Normal text.
 

--- a/vi/lesson-12.md
+++ b/vi/lesson-12.md
@@ -119,6 +119,7 @@ Cấu trúc cơ bản của mã LaTeX được viết trong ví dụ sau:
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{natbib}
 
 \begin{document}
@@ -161,6 +162,7 @@ tên câu lệnh.
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage[style=authoryear]{biblatex}
 \addbibresource{learnlatex.bib} % file of reference info
 

--- a/vi/lesson-13.md
+++ b/vi/lesson-13.md
@@ -38,6 +38,7 @@ Do đó, một văn bản dài có thể trông như thế này:
 <!-- pre0 {% raw %} -->
 ```latex
 \documentclass{book}
+\usepackage[T1]{fontenc}
 \usepackage{biblatex}
 \addbibresource{biblatex-examples.bib}
 

--- a/vi/lesson-14.md
+++ b/vi/lesson-14.md
@@ -75,7 +75,6 @@ Hy Lạp, một số ký hiệu cùng một vài chữ cái tượng hình CJK.
 
 ```latex
 \documentclass{article}
-\usepackage[T1]{fontenc}
 \usepackage{fontspec}
 \setmainfont{texgyretermes-regular.otf}
 \newfontfamily\cjkfont{FandolSong-Regular.otf}

--- a/vi/lesson-14.md
+++ b/vi/lesson-14.md
@@ -75,6 +75,7 @@ Hy Lạp, một số ký hiệu cùng một vài chữ cái tượng hình CJK.
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{fontspec}
 \setmainfont{texgyretermes-regular.otf}
 \newfontfamily\cjkfont{FandolSong-Regular.otf}

--- a/vi/lesson-15.md
+++ b/vi/lesson-15.md
@@ -40,6 +40,7 @@ như TeX Live hay MiKTeX.
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 
 \newcommand\mycommand{\textbold{hmmm}}
 
@@ -56,7 +57,7 @@ Tệp này tạo ra một thông báo lỗi như sau trong tệp log:
 ! Undefined control sequence.
 \mycommand ->\textbold 
                        {hmmm}
-l.7 My command is used here \mycommand
+l.8 My command is used here \mycommand
                                       .
 ? 
 ```
@@ -98,6 +99,7 @@ vì nó làm cho ta tưởng rằng `\mycommand` không được định nghĩa.
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 
 \usepackage[leqno}{amsmath}
 
@@ -120,7 +122,7 @@ Mặc dù thông báo lỗi không giúp ích được nhiều, hai dòng kế t
 vị trí của lỗi bằng việc sử dụng ký tự xuống dòng tại điểm lỗi:
 
 ```
-l.3 \usepackage[leqno}
+l.4 \usepackage[leqno}
                       {amsmath}
 ```
 {: .noedit :}
@@ -130,6 +132,7 @@ l.3 \usepackage[leqno}
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 
 \usepackage{amsmathz}
 
@@ -153,6 +156,7 @@ tìm đang thật sự bị thiếu và cần phải được cài đặt đúng
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 
 \begin{document}
 

--- a/vi/lesson-16.md
+++ b/vi/lesson-16.md
@@ -80,6 +80,7 @@ Làm cách nào để tạo ra một MWE? Thông thường cách dễ nhất là
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \begin{document}
 Text
 \end{document}

--- a/vi/more-04.md
+++ b/vi/more-04.md
@@ -9,6 +9,7 @@ thiết lập các thông tin văn bản và một câu lệnh để sử dụng
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \begin{document}
 \author{A.~N.~Other \and D.~Nobacon} % Tác giả
 \title{Some things I did}            % Tiêu đề văn bản
@@ -37,6 +38,7 @@ sau để hiểu hơn về kiểu danh sách này).
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \begin{document}
 \begin{description}
 \item[Dog:] member of the genus Canis, which forms part of the wolf-like canids,

--- a/vi/more-05.md
+++ b/vi/more-05.md
@@ -21,6 +21,7 @@ hoạt động của nó:
 
 ```latex
 \documentclass{beamer}
+\usepackage[T1]{fontenc}
 \begin{document}
 
 \begin{frame}{A first frame}
@@ -56,6 +57,7 @@ trang giấy theo nội dung văn bản.
 
 ```latex
 \documentclass{standalone}
+\usepackage[T1]{fontenc}
 \begin{document}
 A simple document: this will be a very small box!
 \end{document}

--- a/vi/more-06.md
+++ b/vi/more-06.md
@@ -19,6 +19,7 @@ có một bàn phím hỗ trợ tiếng Đức.
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 
 \usepackage[ngerman]{babel} % Chú ý rằng tùy biến là 'ngerman'
 
@@ -42,6 +43,7 @@ dụng. Điều này có thể được thực hiện bằng cách đưa tùy bi
 
 ```latex
 \documentclass[ngerman]{article} % Chú ý rằng tùy biến là 'ngerman'
+\usepackage[T1]{fontenc}
 
 \usepackage{babel}
 

--- a/vi/more-07.md
+++ b/vi/more-07.md
@@ -66,6 +66,7 @@ Gói `float` có thể được dùng để làm việc đó.
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{graphicx}
 \usepackage{lipsum}
 \usepackage{float}
@@ -99,6 +100,7 @@ một cách độc lập. Ta có thể làm vậy bằng việc sử dụng gói
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{graphicx}
 \usepackage{lipsum}
 \usepackage{trivfloat}

--- a/vi/more-08.md
+++ b/vi/more-08.md
@@ -22,6 +22,7 @@ ta có thể dùng:
 <!-- {% raw %} -->
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{array}
 
 \begin{document}
@@ -49,6 +50,7 @@ trường hợp như vậy, `\multicolumn` có thể được dùng. Nhớ rằn
 <!-- {% raw %} -->
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{array}
 
 \begin{document}
@@ -75,6 +77,7 @@ thay đổi độ dài này thành một số bất kỳ bằng lệnh `\setleng
 <!-- {% raw %} -->
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{array}
 
 \setlength\tabcolsep{1cm}
@@ -97,6 +100,7 @@ cột hoặc ở hai bên bảng, và đặt đoạn mã vào vị trí đó.
 <!-- {% raw %} -->
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{array}
 
 \begin{document}
@@ -119,6 +123,7 @@ khoảng trống giữa các cột mà thêm đoạn mã vào giữa khoảng tr
 <!-- {% raw %} -->
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{array}
 
 \begin{document}
@@ -140,6 +145,7 @@ khoảng trống giữa các cột mà thêm đoạn mã vào giữa khoảng tr
 <!-- {% raw %} -->
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{array}
 
 \begin{document}
@@ -170,6 +176,7 @@ các đối số khác, kể cả đối số không bắt buộc đặt trong d
 <!-- {% raw %} -->
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{array}
 \usepackage{booktabs}
 
@@ -193,6 +200,7 @@ thập phân:
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{booktabs}
 \usepackage{siunitx}
 \begin{document}
@@ -237,6 +245,7 @@ có thể.
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{array}
 \begin{document}
 
@@ -279,6 +288,7 @@ tự như `tabular*`, nhưng thay vì thay đổi khoảng cách giữa các c�
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{tabularx}
 \begin{document}
 
@@ -374,6 +384,7 @@ về gói tại [hướng dẫn sử dụng của nó](https://texdoc.net/pkg/th
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{array}
 \usepackage{threeparttable}
 \begin{document}
@@ -414,6 +425,7 @@ các cột không quá hẹp so với kích thước chữ.
 
 ```latex
 \documentclass[a4paper]{article}
+\usepackage[T1]{fontenc}
 \usepackage{array}
 \usepackage{ragged2e}
 \begin{document}
@@ -463,6 +475,7 @@ Ta có thể lồng các `tabular`:
 <!-- {% raw %} -->
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{array}
 
 \begin{document}
@@ -487,6 +500,7 @@ này: ta có thể dùng `t` (**t**op &ndash; phía trên), `c` (**center** &nda
 <!-- {% raw %} -->
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{array}
 
 \begin{document}
@@ -523,6 +537,7 @@ gia tăng "độ sâu" của chúng. Ta có thể dùng `\extrarowheight` cho vi
 
 ```latex
 \documentclass[a4paper]{article}
+\usepackage[T1]{fontenc}
 \usepackage{array}
 \begin{document}
 

--- a/vi/more-09.md
+++ b/vi/more-09.md
@@ -10,6 +10,7 @@ báo *sau cùng*.
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage[hidelinks]{hyperref}
 \begin{document}
 

--- a/vi/more-10.md
+++ b/vi/more-10.md
@@ -13,6 +13,7 @@ tên môi trường sẽ tắt chức năng đánh số các dòng.
 
 ```latex
 \documentclass[a4paper]{article}
+\usepackage[T1]{fontenc}
 \usepackage{amsmath}
 
 \begin{document}
@@ -39,6 +40,7 @@ thức được hiển thị trên một dòng, như trong ví dụ sau:
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{amsmath}
 \begin{document}
 Aligned equations
@@ -55,6 +57,7 @@ nhỏ trong một công thức nào đó (hãy thử chúng để hiểu cách h
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{amsmath}
 \begin{document}
 Aligned:
@@ -77,6 +80,7 @@ căn chỉnh cả môi trường theo chiều dọc so với các thành phần 
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{amsmath}
 \begin{document}
 \begin{itemize}
@@ -103,6 +107,7 @@ thẳng).
 
 ```latex
 \documentclass[a4paper]{article}
+\usepackage[T1]{fontenc}
 
 \begin{document}
 $(x+y)(x-y)=x^{2}-y^{2}$
@@ -123,6 +128,7 @@ phần của một công thức nào đó, ta có thể dùng lệnh `\bm` từ 
 
 ```latex
 \documentclass[a4paper]{article}
+\usepackage[T1]{fontenc}
 \usepackage{bm}
 
 \begin{document}
@@ -142,6 +148,7 @@ báo bảng để căn lề các ô trong ma trận.
 
 ```latex
 \documentclass[a4paper]{article}
+\usepackage[T1]{fontenc}
 \usepackage{mathtools}
 
 \begin{document}

--- a/vi/more-11.md
+++ b/vi/more-11.md
@@ -10,6 +10,7 @@ các trường hợp &ndash; bạn nên để LaTeX xử lý chúng một cách 
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \begin{document}
 One small paragraph, which we have filled out a little to make sure you can
 see the effect here!

--- a/vi/more-13.md
+++ b/vi/more-13.md
@@ -15,6 +15,7 @@ cần thực hiện ba lệnh:
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 \usepackage{imakeidx}
 \makeindex
 \begin{document}

--- a/vi/more-15.md
+++ b/vi/more-15.md
@@ -12,6 +12,7 @@ bài chính, TeX vẫn đánh dấu vị trí lỗi chính xác.
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 
 \usepackage{amsmath}
 
@@ -29,7 +30,7 @@ bài chính, TeX vẫn đánh dấu vị trí lỗi chính xác.
 Lỗi sẽ được thông báo tại dòng 11:
 
 ```
-l.11 \end{align}
+l.12 \end{align}
 ```
 {: .noedit :}
 
@@ -56,6 +57,7 @@ lỗi đầu tiên.
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 
 \begin{document}
 Text_word  $\alpha + \beta$.
@@ -72,7 +74,7 @@ TeX có phát hiện lỗi này một cách chính xác với thông báo lỗi 
 ! Missing $ inserted.
 <inserted text> 
                 $
-l.4 Text_
+l.5 Text_
          word  $\alpha + \beta$.
 ?
 ```
@@ -87,7 +89,7 @@ này cho ta thêm một lỗi nữa.
 ! Missing $ inserted.
 <inserted text> 
                 $
-l.4 Text_word  $\alpha
+l.5 Text_word  $\alpha
                        + \beta$.
 ? 
 ```
@@ -105,6 +107,7 @@ trong tệp log, hãy thêm `% !TEX log` vào đầu đoạn mã.
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
 
 \begin{document}
 


### PR DESCRIPTION
This adds `\usepackage[T1]{fontenc}` to Latin script pdflatex examples, and adjusts the error lines in en,pt,vi  

It adds a line (just in en) that gives a forward reference to lesson 06 on packages from the first use in lesson 03.  See the discussion in issue #66