### PR TITLE
Translation of ToC tags (partially fixes #101)

### DIFF
--- a/en/extra-01.md
+++ b/en/extra-01.md
@@ -1,7 +1,7 @@
 ---
 lang: "en"
 title: "Examples for further study"
-description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque felis orci, faucibus eget sollicitudin vel, varius eget ipsum. Duis sed sodales leo."
+description: "This lesson shows assorted examples of other popular packages that were not covered in the main lessons."
 toc-anchor-text: "Examples for further study"
 ---
 

--- a/en/help.md
+++ b/en/help.md
@@ -1,7 +1,7 @@
 ---
 lang: "en"
 title: "Using the learnlatex.org site"
-description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque felis orci, faucibus eget sollicitudin vel, varius eget ipsum. Duis sed sodales leo."
+description: "This page explains the learnlatex.org website itself and how to best make use of it."
 permalink: /en/help
 ---
 

--- a/en/language-01.md
+++ b/en/language-01.md
@@ -1,7 +1,7 @@
 ---
 lang: "en"
 title: "Language-specifics for English"
-description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque felis orci, faucibus eget sollicitudin vel, varius eget ipsum. Duis sed sodales leo."
+description: "This lesson shows language-specific details for typesetting text in English."
 next: "extra-01"
 toc-anchor-text: "Language-specifics for English"
 ---

--- a/en/lesson-02.md
+++ b/en/lesson-02.md
@@ -1,7 +1,7 @@
 ---
 lang: "en"
 title: "Working with LaTeX"
-description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque felis orci, faucibus eget sollicitudin vel, varius eget ipsum. Duis sed sodales leo."
+description: "This lesson explains what a TeX system is and which are the most common ones, it lists some of the text editors usually used with LaTeX, and the online systems which have integrated editors."
 toc-anchor-text: "Working with LaTeX"
 toc-description: "TeX systems and LaTeX text editors."
 ---

--- a/en/lesson-03.md
+++ b/en/lesson-03.md
@@ -1,7 +1,7 @@
 ---
 lang: "en"
 title: "Your first LaTeX document"
-description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque felis orci, faucibus eget sollicitudin vel, varius eget ipsum. Duis sed sodales leo."
+description: "This lesson shows the basic structure of a LaTeX document, and how to build it into a PDF file, as well as the main special characters used to control LaTeX."
 toc-anchor-text: "LaTeX documents"
 toc-description: "The mixture of text and commands."
 ---

--- a/en/lesson-03.md
+++ b/en/lesson-03.md
@@ -3,7 +3,7 @@ lang: "en"
 title: "Your first LaTeX document"
 description: "This lesson shows the basic structure of a LaTeX document, and how to build it into a PDF file, as well as the main special characters used to control LaTeX."
 toc-anchor-text: "LaTeX documents"
-toc-description: "The mixture of text and commands."
+toc-description: "The basic structure of a document."
 ---
 
 Our first LaTeX document is going to be very simple: the idea is to show you

--- a/en/lesson-04.md
+++ b/en/lesson-04.md
@@ -1,7 +1,7 @@
 ---
 lang: "en"
 title: "Logical structure"
-description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque felis orci, faucibus eget sollicitudin vel, varius eget ipsum. Duis sed sodales leo."
+description: "This lesson shows some basic formatting commands, and compares them with semantic formatting with sectioning commands and lists."
 toc-anchor-text: "Logical structure"
 toc-description: "Structure and visual presentation."
 ---

--- a/en/lesson-05.md
+++ b/en/lesson-05.md
@@ -1,7 +1,7 @@
 ---
 lang: "en"
 title: "Using document classes to influence design"
-description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque felis orci, faucibus eget sollicitudin vel, varius eget ipsum. Duis sed sodales leo."
+description: "This lesson explains what a document class is and how it can influence a document layout, and lists the main classes you can find in a TeX distribution."
 toc-anchor-text: "Document classes"
 toc-description: "Setting the general document layout."
 ---

--- a/en/lesson-06.md
+++ b/en/lesson-06.md
@@ -1,7 +1,7 @@
 ---
 lang: "en"
 title: "Extending LaTeX using packages and definitions"
-description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque felis orci, faucibus eget sollicitudin vel, varius eget ipsum. Duis sed sodales leo."
+description: "This lesson shows how you can extend LaTeX to your needs and change its layout further by using different packages, and shows how you can define your own commands."
 toc-anchor-text: "Extending LaTeX"
 toc-description: "Using packages and definitions."
 ---

--- a/en/lesson-07.md
+++ b/en/lesson-07.md
@@ -1,7 +1,7 @@
 ---
 lang: "en"
 title: "Including graphics and making things 'float'"
-description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque felis orci, faucibus eget sollicitudin vel, varius eget ipsum. Duis sed sodales leo."
+description: "This lesson shows how you can include external graphics files into your document, how to change their appearance, and how to make them float automatically to the proper location in the PDF."
 toc-anchor-text: "Using graphics"
 toc-description: "Appearance, spacing and positioning."
 ---

--- a/en/lesson-08.md
+++ b/en/lesson-08.md
@@ -1,7 +1,7 @@
 ---
 lang: "en"
 title: "Tables"
-description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque felis orci, faucibus eget sollicitudin vel, varius eget ipsum. Duis sed sodales leo."
+description: "This lesson shows how you can build tables in LaTeX, influence the alignment of the cells, add rules to the table, and merge cells."
 toc-anchor-text: "LaTeX tables"
 toc-description: "Fundamentals of working with tables."
 ---

--- a/en/lesson-09.md
+++ b/en/lesson-09.md
@@ -1,7 +1,7 @@
 ---
 lang: "en"
 title: "Cross-referencing"
-description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque felis orci, faucibus eget sollicitudin vel, varius eget ipsum. Duis sed sodales leo."
+description: "This lesson shows how to refer to numbered elements in a document, like figures, tables and sections."
 toc-anchor-text: "Cross-referencing"
 toc-description: "Refering to figures, tables, etc."
 ---

--- a/en/lesson-10.md
+++ b/en/lesson-10.md
@@ -1,7 +1,7 @@
 ---
 lang: "en"
 title: "Mathematics"
-description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque felis orci, faucibus eget sollicitudin vel, varius eget ipsum. Duis sed sodales leo."
+description: "This lesson presents LaTeX's math mode and how you can type inline and display formulas, the extensions provided by the amsmath package, and how to change fonts in math."
 toc-anchor-text: "Mathematics"
 toc-description: "Math mode and mathematical notation."
 ---

--- a/en/lesson-11.md
+++ b/en/lesson-11.md
@@ -1,7 +1,7 @@
 ---
 lang: "en"
 title: "Formatting: fonts and spacing"
-description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque felis orci, faucibus eget sollicitudin vel, varius eget ipsum. Duis sed sodales leo."
+description: "This lesson shows how to change the spacing elements in a document and how to add explicit formatting instructions to the LaTeX source."
 toc-anchor-text: "Fonts & spacing"
 toc-description: "Text formatting for visual presentation."
 ---

--- a/en/lesson-12.md
+++ b/en/lesson-12.md
@@ -1,7 +1,7 @@
 ---
 lang: "en"
 title: "Citations and references"
-description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque felis orci, faucibus eget sollicitudin vel, varius eget ipsum. Duis sed sodales leo."
+description: "This lesson show the basics of reference databases and how to build your own, how to use this databases in your documents using the two major workflows available, and how to choose between them."
 toc-anchor-text: "Citations & references"
 toc-description: "Working with reference databases."
 ---

--- a/en/lesson-13.md
+++ b/en/lesson-13.md
@@ -1,7 +1,7 @@
 ---
 lang: "en"
 title: "Structuring longer documents"
-description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque felis orci, faucibus eget sollicitudin vel, varius eget ipsum. Duis sed sodales leo."
+description: "This lesson shows how LaTeX allows you to split your sources into smaller, more manageable files, and how this can make building a long document easier and faster."
 toc-anchor-text: "Structuring sources"
 toc-description: "Spliting up sources in a controlled way."
 ---

--- a/en/lesson-14.md
+++ b/en/lesson-14.md
@@ -1,7 +1,7 @@
 ---
 lang: "en"
 title: "Selecting fonts and using Unicode engines"
-description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque felis orci, faucibus eget sollicitudin vel, varius eget ipsum. Duis sed sodales leo."
+description: "This lesson gives context on how LaTeX interprets Unicode input and how that affects what you type and the fonts you use, and how that changes in modern engines with Unicode and OpenType fonts support."
 toc-anchor-text: "Fonts & Unicode engines"
 toc-description: "Selecting fonts and file encoding."
 ---

--- a/en/lesson-15.md
+++ b/en/lesson-15.md
@@ -1,7 +1,7 @@
 ---
 lang: "en"
 title: "Dealing with errors"
-description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque felis orci, faucibus eget sollicitudin vel, varius eget ipsum. Duis sed sodales leo."
+description: "This lesson shows some common errors in LaTeX documents, what they mean, and how to work around them."
 toc-anchor-text: "Error handling"
 toc-description: "Dealing with unexpected behaviors."
 ---

--- a/en/lesson-16.md
+++ b/en/lesson-16.md
@@ -1,7 +1,7 @@
 ---
 lang: "en"
 title: "Accessing documentation and getting help"
-description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque felis orci, faucibus eget sollicitudin vel, varius eget ipsum. Duis sed sodales leo."
+description: "This lesson shows the main sources of documentation for LaTeX-related software and packages, and how to seek help when you are in trouble."
 toc-anchor-text: "Help & documentation"
 toc-description: "Accessing help and documentation."
 ---

--- a/en/more-01.md
+++ b/en/more-01.md
@@ -1,7 +1,7 @@
 ---
 lang: "en"
 title: "More on: What is LaTeX and how does it work?"
-description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque felis orci, faucibus eget sollicitudin vel, varius eget ipsum. Duis sed sodales leo."
+description: "This lesson gives more context on the history of LaTeX and other formats available."
 toc-anchor-text: "More on: What is LaTeX and how does it work?"
 ---
 

--- a/en/more-02.md
+++ b/en/more-02.md
@@ -1,7 +1,7 @@
 ---
 lang: "en"
 title: "More on: Working with LaTeX"
-description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque felis orci, faucibus eget sollicitudin vel, varius eget ipsum. Duis sed sodales leo."
+description: "This lesson gives more detail on what LaTeX is and the engines it runs on."
 toc-anchor-text: "More on: Working with LaTeX"
 ---
 

--- a/en/more-03.md
+++ b/en/more-03.md
@@ -1,7 +1,7 @@
 ---
 lang: "en"
 title: "More on: Your first LaTeX document"
-description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque felis orci, faucibus eget sollicitudin vel, varius eget ipsum. Duis sed sodales leo."
+description: "This lesson gives more detail on how to run LaTeX, and the special characters it uses and how to insert them in the output PDF."
 toc-anchor-text: "More on: Your first LaTeX document"
 ---
 

--- a/en/more-04.md
+++ b/en/more-04.md
@@ -1,7 +1,7 @@
 ---
 lang: "en"
 title: "More on: Logical structure"
-description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque felis orci, faucibus eget sollicitudin vel, varius eget ipsum. Duis sed sodales leo."
+description: "This lesson shows how to set the document title, and how to make description lists."
 toc-anchor-text: "More on: Logical structure"
 ---
 

--- a/en/more-05.md
+++ b/en/more-05.md
@@ -1,7 +1,7 @@
 ---
 lang: "en"
 title: "More on: Using document classes to influence design"
-description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque felis orci, faucibus eget sollicitudin vel, varius eget ipsum. Duis sed sodales leo."
+description: "This lesson gives information on more specialized document classes for LaTeX."
 toc-anchor-text: "More on: Using document classes to influence design"
 ---
 

--- a/en/more-06.md
+++ b/en/more-06.md
@@ -1,7 +1,7 @@
 ---
 lang: "en"
 title: "More on: Extending LaTeX using packages and definitions"
-description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque felis orci, faucibus eget sollicitudin vel, varius eget ipsum. Duis sed sodales leo."
+description: "This lesson gives more details on package loading, shows the babel package for language selection, and gives more details on custom commands."
 toc-anchor-text: "More on: Extending LaTeX using packages and definitions"
 ---
 

--- a/en/more-07.md
+++ b/en/more-07.md
@@ -1,7 +1,7 @@
 ---
 lang: "en"
 title: "More on: Including graphics and making things 'float'"
-description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque felis orci, faucibus eget sollicitudin vel, varius eget ipsum. Duis sed sodales leo."
+description: "This lesson gives details on how better name and store graphics files to be used with LaTeX, and how you can make your own graphics from within LaTeX."
 toc-anchor-text: "More on: Including graphics and making things 'float'"
 ---
 

--- a/en/more-08.md
+++ b/en/more-08.md
@@ -1,7 +1,7 @@
 ---
 lang: "en"
 title: "More on: Tables"
-description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque felis orci, faucibus eget sollicitudin vel, varius eget ipsum. Duis sed sodales leo."
+description: "This lesson shows more ways to customize a table by styling a column, changing spacing and rules, and further packages that provide different extensions to tables."
 toc-anchor-text: "More on: Tables"
 ---
 

--- a/en/more-09.md
+++ b/en/more-09.md
@@ -1,7 +1,7 @@
 ---
 lang: "en"
 title: "More on: Cross-referencing"
-description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque felis orci, faucibus eget sollicitudin vel, varius eget ipsum. Duis sed sodales leo."
+description: "This lesson shows how you can make links of cross-references by loading the hyperref package."
 toc-anchor-text: "More on: Cross-referencing"
 ---
 

--- a/en/more-10.md
+++ b/en/more-10.md
@@ -1,7 +1,7 @@
 ---
 lang: "en"
 title: "More on: Mathematics"
-description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque felis orci, faucibus eget sollicitudin vel, varius eget ipsum. Duis sed sodales leo."
+description: "This lesson show more amsmath alignment environments, how to make math bold, the math extension package mathtools, and using Unicode input for maths."
 toc-anchor-text: "More on: Mathematics"
 ---
 

--- a/en/more-11.md
+++ b/en/more-11.md
@@ -1,7 +1,7 @@
 ---
 lang: "en"
 title: "More on: Formatting: fonts and spacing"
-description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque felis orci, faucibus eget sollicitudin vel, varius eget ipsum. Duis sed sodales leo."
+description: "This lesson shows how to suppress the paragraph intentation for a single paragraph."
 toc-anchor-text: "More on: Formatting: fonts and spacing"
 ---
 

--- a/en/more-12.md
+++ b/en/more-12.md
@@ -1,7 +1,7 @@
 ---
 lang: "en"
 title: "More on: Citations and references"
-description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque felis orci, faucibus eget sollicitudin vel, varius eget ipsum. Duis sed sodales leo."
+description: "This lesson gives details on non-English bibliographies, how to make references into hyperlinks, and highlights the main differences between BibTeX styles."
 toc-anchor-text: "More on: Citations and references"
 ---
 

--- a/en/more-13.md
+++ b/en/more-13.md
@@ -1,7 +1,7 @@
 ---
 lang: "en"
 title: "More on: Structuring longer documents"
-description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque felis orci, faucibus eget sollicitudin vel, varius eget ipsum. Duis sed sodales leo."
+description: "This lesson shows how to make an index, and how to use the imakeidx package to automate the process."
 toc-anchor-text: "More on: Structuring longer documents"
 ---
 

--- a/en/more-14.md
+++ b/en/more-14.md
@@ -1,7 +1,7 @@
 ---
 lang: "en"
 title: "More on: Selecting fonts and using Unicode engines"
-description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque felis orci, faucibus eget sollicitudin vel, varius eget ipsum. Duis sed sodales leo."
+description: "This lesson shows a basic example in Lua for users who want to write Lua code in their document."
 toc-anchor-text: "More on: Selecting fonts and using Unicode engines"
 ---
 

--- a/en/more-15.md
+++ b/en/more-15.md
@@ -1,7 +1,7 @@
 ---
 lang: "en"
 title: "More on: Dealing with errors"
-description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque felis orci, faucibus eget sollicitudin vel, varius eget ipsum. Duis sed sodales leo."
+description: "This lesson show a few more common errors in LaTeX and explains about chained errors and silent errors."
 toc-anchor-text: "More on: Dealing with errors"
 ---
 

--- a/en/more-16.md
+++ b/en/more-16.md
@@ -1,7 +1,7 @@
 ---
 lang: "en"
 title: "More on: Accessing documentation and getting help"
-description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque felis orci, faucibus eget sollicitudin vel, varius eget ipsum. Duis sed sodales leo."
+description: "This lesson show you where you can find the sources of LaTeX itself."
 toc-anchor-text: "More on: Accessing documentation and getting help"
 ---
 

--- a/pt/extra-01.md
+++ b/pt/extra-01.md
@@ -1,6 +1,8 @@
 ---
 lang: "pt"
 title: "Exemplos para estudo adicional"
+description: "Esta lição mostra exemplos diversos de outros pacotes populares que não foram apresentados nas lições principais."
+toc-anchor-text: "Exemplos para estudo adicional"
 ---
 
 Este curso deu uma visão geral das funcionalidades básicas do LaTeX e alguns

--- a/pt/help.md
+++ b/pt/help.md
@@ -1,6 +1,7 @@
 ---
 lang: "pt"
 title: "Usando o learnlatex.org"
+description: "Esta página explica o próprio site learnlatex.org e como fazer o melhor uso dele."
 permalink: /pt/help
 ---
 

--- a/pt/language-01.md
+++ b/pt/language-01.md
@@ -1,6 +1,7 @@
 ---
 lang: "pt"
 title: "Lição específica para a língua Portuguesa"
+description: "Esta lição mostra detalhes específicos de linguagem para escrever textos em Português."
 next: "extra-01"
 toc-anchor-text: "Lição específica para a língua Portuguesa"
 ---

--- a/pt/language-01.md
+++ b/pt/language-01.md
@@ -2,6 +2,7 @@
 lang: "pt"
 title: "Lição específica para a língua Portuguesa"
 next: "extra-01"
+toc-anchor-text: "Lição específica para a língua Portuguesa"
 ---
 
 Como a língua Portuguesa usa o alfabeto Latino, assim como a língua Inglesa, o

--- a/pt/lesson-01.md
+++ b/pt/lesson-01.md
@@ -1,6 +1,8 @@
 ---
 lang: "pt"
 title: "O que é LaTeX e como funciona?"
+toc-anchor-text: "O Básico de LaTeX"
+toc-description: "O que é LaTeX e como funciona?"
 ---
 
 Diferente de processadores de texto comuns, como o _Microsoft Word_ ou o

--- a/pt/lesson-01.md
+++ b/pt/lesson-01.md
@@ -1,6 +1,7 @@
 ---
 lang: "pt"
 title: "O que é LaTeX e como funciona?"
+description: "Esta lição explica o básico de o que é o LaTeX e como ele funciona em contraste a processadores de texto comuns como o Microsoft Word ou o LibreOffice Writer."
 toc-anchor-text: "O Básico de LaTeX"
 toc-description: "O que é LaTeX e como funciona?"
 ---

--- a/pt/lesson-02.md
+++ b/pt/lesson-02.md
@@ -1,6 +1,8 @@
 ---
 lang: "pt"
 title: "Trabalhando com LaTeX"
+toc-anchor-text: "Trabalhando com LaTeX"
+toc-description: "Sistemas TeX e editores de texto."
 ---
 
 Diferente de muitos programas de computador, o LaTeX não é uma única aplicação

--- a/pt/lesson-02.md
+++ b/pt/lesson-02.md
@@ -1,6 +1,7 @@
 ---
 lang: "pt"
 title: "Trabalhando com LaTeX"
+description: "Esta lição explica o que é um sistema TeX e quais os mais comuns, lista alguns dos editores de texto comumente utilizados para LaTeX, e os sistemas online que contam também com editores integrados."
 toc-anchor-text: "Trabalhando com LaTeX"
 toc-description: "Sistemas TeX e editores de texto."
 ---

--- a/pt/lesson-03.md
+++ b/pt/lesson-03.md
@@ -1,6 +1,7 @@
 ---
 lang: "pt"
 title: "Seu primeiro documento LaTeX"
+description: "Esta lição mostra a estrutura básica de um documento LaTeX, e como produzir um PDF com ele, assim como os principais caracteres especiais usados para controlar o LaTeX."
 toc-anchor-text: "Documentos LaTeX"
 toc-description: "A estrutura básica de um documento."
 ---

--- a/pt/lesson-03.md
+++ b/pt/lesson-03.md
@@ -1,6 +1,8 @@
 ---
 lang: "pt"
 title: "Seu primeiro documento LaTeX"
+toc-anchor-text: "Documentos LaTeX"
+toc-description: "A estrutura básica de um documento."
 ---
 
 Nosso primeiro documento LaTeX será muito simples: a ideia é lhe mostrar como um

--- a/pt/lesson-04.md
+++ b/pt/lesson-04.md
@@ -1,6 +1,8 @@
 ---
 lang: "pt"
 title: "Estrutura Lógica"
+toc-anchor-text: "Estrutura Lógica"
+toc-description: "Estrutura e representação visual."
 ---
 
 O LaTeX possui meios de você focar na estrutura lógica do seu documento, assim

--- a/pt/lesson-04.md
+++ b/pt/lesson-04.md
@@ -1,6 +1,7 @@
 ---
 lang: "pt"
 title: "Estrutura Lógica"
+description: "Esta lição mostra alguns comandos básicos de formatação, e compara-os com formatação semântica usando comandos de secionamento e listas."
 toc-anchor-text: "Estrutura Lógica"
 toc-description: "Estrutura e representação visual."
 ---

--- a/pt/lesson-05.md
+++ b/pt/lesson-05.md
@@ -1,6 +1,8 @@
 ---
 lang: "pt"
 title: "Usando classes de documentos para influenciar o design"
+toc-anchor-text: "Classes de Documento"
+toc-description: "Configurando a aparência geral do documento."
 ---
 
 ## O que uma classe de documento faz

--- a/pt/lesson-05.md
+++ b/pt/lesson-05.md
@@ -1,6 +1,7 @@
 ---
 lang: "pt"
 title: "Usando classes de documentos para influenciar o design"
+description: "Esta lição explica o que é uma classe de documento e como ela pode influenciar a aparência de um documento, e lista as principais classes que você vai encontrar em uma distribuição de TeX."
 toc-anchor-text: "Classes de Documento"
 toc-description: "Configurando a aparência geral do documento."
 ---

--- a/pt/lesson-06.md
+++ b/pt/lesson-06.md
@@ -1,6 +1,7 @@
 ---
 lang: "pt"
 title: "Extendendo o LaTeX usando pacotes e definições"
+description: "Esta lição mostra como você pode estender o LaTeX de acordo com a sua necessidade e mudar a aparência do document usando diferentes pacotes, e mostra como você pode definir seus próprios comandos."
 toc-anchor-text: "Extendendo o LaTeX"
 toc-description: "Usando pacotes e definições."
 ---

--- a/pt/lesson-06.md
+++ b/pt/lesson-06.md
@@ -1,6 +1,8 @@
 ---
 lang: "pt"
 title: "Extendendo o LaTeX usando pacotes e definições"
+toc-anchor-text: "Extendendo o LaTeX"
+toc-description: "Usando pacotes e definições."
 ---
 
 Depois de declarar uma classe, no preâmbulo você pode modificar funcionalidades

--- a/pt/lesson-07.md
+++ b/pt/lesson-07.md
@@ -1,6 +1,8 @@
 ---
 lang: "pt"
 title: "Incluindo gráficos e fazendo coisas 'flutuarem'"
+toc-anchor-text: "Usando gráficos"
+toc-description: "Aparência, espaçamento e posicionamento."
 ---
 
 ## Incluindo gráficos

--- a/pt/lesson-07.md
+++ b/pt/lesson-07.md
@@ -1,6 +1,7 @@
 ---
 lang: "pt"
 title: "Incluindo gráficos e fazendo coisas 'flutuarem'"
+description: "Esta lição mostra como você pode incluir externos no seu documento, como mudar a sua aparência, e como fazê-los flutuar para a posição apropriada no PDF."
 toc-anchor-text: "Usando gráficos"
 toc-description: "Aparência, espaçamento e posicionamento."
 ---

--- a/pt/lesson-08.md
+++ b/pt/lesson-08.md
@@ -1,6 +1,8 @@
 ---
 lang: "pt"
 title: "Tabelas"
+toc-anchor-text: "Tabelas no LaTeX"
+toc-description: "Princípios básicos de tabelas."
 ---
 
 ## Tabelas básicas

--- a/pt/lesson-08.md
+++ b/pt/lesson-08.md
@@ -1,6 +1,7 @@
 ---
 lang: "pt"
 title: "Tabelas"
+description: "Esta lição mostra como você pode construir tabelas no LaTeX, influenciar o alinhamento das células, adicionar linhas à tabela, e unir células."
 toc-anchor-text: "Tabelas no LaTeX"
 toc-description: "Princípios básicos de tabelas."
 ---

--- a/pt/lesson-09.md
+++ b/pt/lesson-09.md
@@ -1,6 +1,7 @@
 ---
 lang: "pt"
 title: "Referências cruzadas"
+description: "Essa lição mostra como mencionar elementos numerados em um documento, como figuras, tabelas, e seções."
 toc-anchor-text: "Referências cruzadas"
 toc-description: "Mencionando figuras, tabelas, etc."
 ---

--- a/pt/lesson-09.md
+++ b/pt/lesson-09.md
@@ -1,6 +1,8 @@
 ---
 lang: "pt"
 title: "Referências cruzadas"
+toc-anchor-text: "Referências cruzadas"
+toc-description: "Mencionando figuras, tabelas, etc."
 ---
 
 ## O mecanismo de `\label` e `\ref`

--- a/pt/lesson-10.md
+++ b/pt/lesson-10.md
@@ -1,6 +1,8 @@
 ---
 lang: "pt"
 title: "Matemática"
+toc-anchor-text: "Matemática"
+toc-description: "Modo e notação matemática."
 ---
 
 ## Modo matemático

--- a/pt/lesson-10.md
+++ b/pt/lesson-10.md
@@ -1,6 +1,7 @@
 ---
 lang: "pt"
 title: "Matemática"
+description: "Esta lição apresenta o modo matemático do LaTeX e como você pode escrever equações lineares e em exibição, as extensões do pacote amsmath, e como mudar a fonte em equações."
 toc-anchor-text: "Matemática"
 toc-description: "Modo e notação matemática."
 ---

--- a/pt/lesson-11.md
+++ b/pt/lesson-11.md
@@ -1,6 +1,8 @@
 ---
 lang: "pt"
 title: "Formatação: fontes e espaçamento"
+toc-anchor-text: "Fontes & espaçamento"
+toc-description: "Formatação do texto para apresentação visual."
 ---
 
 ## Espaçamento entre parágrafos

--- a/pt/lesson-11.md
+++ b/pt/lesson-11.md
@@ -1,6 +1,7 @@
 ---
 lang: "pt"
 title: "Formatação: fontes e espaçamento"
+description: "Esta lição mostra como mudar os elementos de espaçamento em um documento e como inserir instruções de formatação explícitas no código fonte."
 toc-anchor-text: "Fontes & espaçamento"
 toc-description: "Formatação do texto para apresentação visual."
 ---

--- a/pt/lesson-12.md
+++ b/pt/lesson-12.md
@@ -1,6 +1,7 @@
 ---
 lang: "pt"
 title: "Citações e referências"
+description: "Esta lição mostra o básico sobre bancos de referências e como construir o seu próprio, como usar esse banco de referências no seu documento usando os dois principais métodos disponíveis, e como escolher entre eles."
 toc-anchor-text: "Citações & referências"
 toc-description: "Trabalhando com bancos de referências."
 ---

--- a/pt/lesson-12.md
+++ b/pt/lesson-12.md
@@ -1,6 +1,8 @@
 ---
 lang: "pt"
 title: "Citações e referências"
+toc-anchor-text: "Citações & referências"
+toc-description: "Trabalhando com bancos de referências."
 ---
 <script>
 preincludes = {

--- a/pt/lesson-13.md
+++ b/pt/lesson-13.md
@@ -1,6 +1,8 @@
 ---
 lang: "pt"
 title: "Estruturando documentos longos"
+toc-anchor-text: "Structuring o código"
+toc-description: "Dividindo o código de forma organizada."
 ---
 
 <script>

--- a/pt/lesson-13.md
+++ b/pt/lesson-13.md
@@ -1,6 +1,7 @@
 ---
 lang: "pt"
 title: "Estruturando documentos longos"
+description: "Esta lição mostra como o LaTeX permite dividir seu código em arquivos menores, mais fáceis de editar, e como isso pode tornar a produção de um documento longo mais fácil e rápido."
 toc-anchor-text: "Structuring o código"
 toc-description: "Dividindo o código de forma organizada."
 ---

--- a/pt/lesson-14.md
+++ b/pt/lesson-14.md
@@ -1,6 +1,7 @@
 ---
 lang: "pt"
 title: "Trocando fontes e usando interpretadores Unicode"
+description: "Esta lição dá contexto sobre como o LaTeX interpreta entrada de texto com Unicode e como isso afeta o que você digita e as fontes que você usa, e como isso muda em interpretadores modernos com suporte a Unicode e fontes OpenType."
 toc-anchor-text: "Fontes & interpretadores Unicode"
 toc-description: "Selecionando fontes e codificação."
 ---

--- a/pt/lesson-14.md
+++ b/pt/lesson-14.md
@@ -1,6 +1,8 @@
 ---
 lang: "pt"
 title: "Trocando fontes e usando interpretadores Unicode"
+toc-anchor-text: "Fontes & interpretadores Unicode"
+toc-description: "Selecionando fontes e codificação."
 ---
 
 Quando o TeX e o LaTeX começaram a ser amplamente utilizados eles funcionavam

--- a/pt/lesson-15.md
+++ b/pt/lesson-15.md
@@ -1,6 +1,6 @@
 ---
 lang: "pt"
-title: "Lidando com erros"
+title: "Resolvendo erros"
 description: "Esta lição mostra alguns erros comuns em documentos, o que eles significam, e como resolvê-los."
 toc-anchor-text: "Resolvendo erros"
 toc-description: "Trabalhando com comportamento inesperado."

--- a/pt/lesson-15.md
+++ b/pt/lesson-15.md
@@ -1,6 +1,8 @@
 ---
 lang: "pt"
 title: "Lidando com erros"
+toc-anchor-text: "Resolvendo erros"
+toc-description: "Trabalhando com comportamento inesperado."
 ---
 
 Diferente de um sistema típico de processamento de texto, o LaTeX tem um ciclo

--- a/pt/lesson-15.md
+++ b/pt/lesson-15.md
@@ -1,6 +1,7 @@
 ---
 lang: "pt"
 title: "Lidando com erros"
+description: "Esta lição mostra alguns erros comuns em documentos, o que eles significam, e como resolvê-los."
 toc-anchor-text: "Resolvendo erros"
 toc-description: "Trabalhando com comportamento inesperado."
 ---

--- a/pt/lesson-16.md
+++ b/pt/lesson-16.md
@@ -1,6 +1,8 @@
 ---
 lang: "pt"
 title: "Acessando documentação e obtendo ajuda"
+toc-anchor-text: "Ajuda & documentação"
+toc-description: "Acessando ajuda e documentação."
 ---
 
 Há várias formas de acessar a documentação de um pacote ou classe.

--- a/pt/lesson-16.md
+++ b/pt/lesson-16.md
@@ -1,6 +1,7 @@
 ---
 lang: "pt"
 title: "Acessando documentação e obtendo ajuda"
+description: "Esta lição mostra as principais fontes de documentação para pacotes e software relacionado ao LaTeX, e como você pode buscar ajuda quando estiver com problemas."
 toc-anchor-text: "Ajuda & documentação"
 toc-description: "Acessando ajuda e documentação."
 ---

--- a/pt/more-01.md
+++ b/pt/more-01.md
@@ -1,6 +1,7 @@
 ---
 lang: "pt"
 title: "Veja mais sobre: O que é LaTeX e como funciona?"
+description: "Esta lição dá mais detalhes sobre a história do LaTeX e outros formatos disponíveis."
 toc-anchor-text: "Veja mais sobre: O que é LaTeX e como funciona?"
 ---
 

--- a/pt/more-01.md
+++ b/pt/more-01.md
@@ -1,6 +1,7 @@
 ---
 lang: "pt"
 title: "Veja mais sobre: O que é LaTeX e como funciona?"
+toc-anchor-text: "Veja mais sobre: O que é LaTeX e como funciona?"
 ---
 
 O nome "LaTeX" é formado por dois componentes, "La" e "TeX".  A seguir vamos

--- a/pt/more-02.md
+++ b/pt/more-02.md
@@ -1,6 +1,7 @@
 ---
 lang: "pt"
 title: "Veja mais sobre: Trabalhando com LaTeX"
+toc-anchor-text: "Veja mais sobre: Trabalhando com LaTeX"
 ---
 
 Para a maioria dos nossos exemplos, não usamos um programa chamado `latex`, ao

--- a/pt/more-02.md
+++ b/pt/more-02.md
@@ -1,6 +1,7 @@
 ---
 lang: "pt"
 title: "Veja mais sobre: Trabalhando com LaTeX"
+description: "Esta lição dá mais detalhes sobre o que é o LaTeX e os interpretadores sobre os quais ele funciona."
 toc-anchor-text: "Veja mais sobre: Trabalhando com LaTeX"
 ---
 

--- a/pt/more-03.md
+++ b/pt/more-03.md
@@ -1,6 +1,7 @@
 ---
 lang: "pt"
 title: "Veja mais sobre: Seu primeiro documento LaTeX"
+description: "Esta lição dá mais detalhes sobre como executar o LaTeX, e sobre os caracteres especiais utilizados e como inseri-los no PDF."
 toc-anchor-text: "Veja mais sobre: Seu primeiro documento LaTeX"
 ---
 

--- a/pt/more-03.md
+++ b/pt/more-03.md
@@ -1,6 +1,7 @@
 ---
 lang: "pt"
 title: "Veja mais sobre: Seu primeiro documento LaTeX"
+toc-anchor-text: "Veja mais sobre: Seu primeiro documento LaTeX"
 ---
 
 ## Executando o LaTeX

--- a/pt/more-04.md
+++ b/pt/more-04.md
@@ -1,6 +1,7 @@
 ---
 lang: "pt"
 title: "Veja mais sobre: Estrutura Lógica"
+description: "Esta lição mostra como definir o título de um documento, e como fazer listas desritivas."
 toc-anchor-text: "Veja mais sobre: Estrutura Lógica"
 ---
 

--- a/pt/more-04.md
+++ b/pt/more-04.md
@@ -1,6 +1,7 @@
 ---
 lang: "pt"
 title: "Veja mais sobre: Estrutura Lógica"
+toc-anchor-text: "Veja mais sobre: Estrutura Lógica"
 ---
 
 ## Título do documento

--- a/pt/more-05.md
+++ b/pt/more-05.md
@@ -1,6 +1,7 @@
 ---
 lang: "pt"
 title: "Veja mais sobre: Usando classes de documentos para influenciar o design"
+description: "Esta lição dá mais informações sobre classes de documento de aplicação especializada para o LaTeX."
 toc-anchor-text: "Veja mais sobre: Usando classes de documentos para influenciar o design"
 ---
 

--- a/pt/more-05.md
+++ b/pt/more-05.md
@@ -1,6 +1,7 @@
 ---
 lang: "pt"
 title: "Veja mais sobre: Usando classes de documentos para influenciar o design"
+toc-anchor-text: "Veja mais sobre: Usando classes de documentos para influenciar o design"
 ---
 
 ## Classes específicas de revistas

--- a/pt/more-06.md
+++ b/pt/more-06.md
@@ -1,6 +1,7 @@
 ---
 lang: "pt"
 title: "Veja mais sobre: Extendendo o LaTeX usando pacotes e definições"
+description: "Esta lição dá mais detalhes sobre carregamento de pacotes, apresenta o pacote babel para selecionar o idioma, e dá mais detalhes sobre comandos personalizados."
 toc-anchor-text: "Veja mais sobre: Extendendo o LaTeX usando pacotes e definições"
 ---
 

--- a/pt/more-06.md
+++ b/pt/more-06.md
@@ -1,6 +1,7 @@
 ---
 lang: "pt"
 title: "Veja mais sobre: Extendendo o LaTeX usando pacotes e definições"
+toc-anchor-text: "Veja mais sobre: Extendendo o LaTeX usando pacotes e definições"
 ---
 
 ## Carregando múltiplos pacotes

--- a/pt/more-07.md
+++ b/pt/more-07.md
@@ -1,6 +1,7 @@
 ---
 lang: "pt"
 title: "Veja mais sobre: Incluindo gráficos e fazendo coisas 'flutuarem'"
+description: "Esta lição dá mais detalhes sobre boas práticas para dar nome e armazenar gráficos para usar com o LaTeX, e como você pode fazer seus próprios gráficos de dentro do LaTeX."
 toc-anchor-text: "Veja mais sobre: Incluindo gráficos e fazendo coisas 'flutuarem'"
 ---
 

--- a/pt/more-07.md
+++ b/pt/more-07.md
@@ -1,6 +1,7 @@
 ---
 lang: "pt"
 title: "Veja mais sobre: Incluindo gráficos e fazendo coisas 'flutuarem'"
+toc-anchor-text: "Veja mais sobre: Incluindo gráficos e fazendo coisas 'flutuarem'"
 ---
 
 ## Nomeando arquivos de gráficos

--- a/pt/more-08.md
+++ b/pt/more-08.md
@@ -1,6 +1,7 @@
 ---
 lang: "pt"
 title: "Veja mais sobre: Tabelas"
+description: "Esta lição mostra formas de personalizar uma tabela aplicando estilos a uma coluna, modificando espaçamento e linhas, e outros pacotes que fornecem diferentes extensões para tabelas."
 toc-anchor-text: "Veja mais sobre: Tabelas"
 ---
 

--- a/pt/more-08.md
+++ b/pt/more-08.md
@@ -1,6 +1,7 @@
 ---
 lang: "pt"
 title: "Veja mais sobre: Tabelas"
+toc-anchor-text: "Veja mais sobre: Tabelas"
 ---
 
 ## Outros símbolos de preâmbulo para tabelas

--- a/pt/more-09.md
+++ b/pt/more-09.md
@@ -1,6 +1,7 @@
 ---
 lang: "pt"
 title: "Veja mais sobre: Referências cruzadas"
+toc-anchor-text: "Veja mais sobre: Referências cruzadas"
 ---
 
 ## Transformando referências em links

--- a/pt/more-09.md
+++ b/pt/more-09.md
@@ -1,6 +1,7 @@
 ---
 lang: "pt"
 title: "Veja mais sobre: Referências cruzadas"
+description: "Esta lição mostra como você pode transformar referências cruzadas em links carregando o pacote hyperref."
 toc-anchor-text: "Veja mais sobre: Referências cruzadas"
 ---
 

--- a/pt/more-10.md
+++ b/pt/more-10.md
@@ -1,6 +1,7 @@
 ---
 lang: "pt"
 title: "Veja mais sobre: Matemática"
+description: "Esta lição mostra mais ambientes de alinhamento do amsmath, como fazer símbolos matemáticos em negrito, o pacote de extensão de matemática mathtools, e usando entrada Unicode para equações."
 toc-anchor-text: "Veja mais sobre: Matemática"
 ---
 

--- a/pt/more-10.md
+++ b/pt/more-10.md
@@ -1,6 +1,7 @@
 ---
 lang: "pt"
 title: "Veja mais sobre: Matemática"
+toc-anchor-text: "Veja mais sobre: Matemática"
 ---
 
 ## Mais ambientes de alinhamento do `amsmath`

--- a/pt/more-11.md
+++ b/pt/more-11.md
@@ -1,6 +1,7 @@
 ---
 lang: "pt"
 title: "Veja mais sobre: Formatação: fontes e espaçamento"
+toc-anchor-text: "Veja mais sobre: Formatação: fontes e espaçamento"
 ---
 
 ## Suprimindo a indentação de um parágrafo

--- a/pt/more-11.md
+++ b/pt/more-11.md
@@ -1,6 +1,7 @@
 ---
 lang: "pt"
 title: "Veja mais sobre: Formatação: fontes e espaçamento"
+description: "Esta lição mostra como omitir a indentação de parágrafo para um único parágrafo."
 toc-anchor-text: "Veja mais sobre: Formatação: fontes e espaçamento"
 ---
 

--- a/pt/more-12.md
+++ b/pt/more-12.md
@@ -1,6 +1,7 @@
 ---
 lang: "pt"
 title: "Veja mais sobre: Citações e referências"
+description: "Esta lição dá mais detalhes sobre bibliografia em outros idiomas, como transformar referências em link, e apresenta as principais diferenças entre estilos do BibTeX."
 toc-anchor-text: "Veja mais sobre: Citações e referências"
 ---
 

--- a/pt/more-12.md
+++ b/pt/more-12.md
@@ -1,6 +1,7 @@
 ---
 lang: "pt"
 title: "Veja mais sobre: Citações e referências"
+toc-anchor-text: "Veja mais sobre: Citações e referências"
 ---
 
 ## Organização alfabética em outros idiomas

--- a/pt/more-13.md
+++ b/pt/more-13.md
@@ -1,6 +1,7 @@
 ---
 lang: "pt"
 title: "Veja mais sobre: Estruturando documentos longos"
+description: "Esta lição mostra como fazer um índice remissivo, e como usar o pacote imakeidx para automatizar o procsso."
 toc-anchor-text: "Veja mais sobre: Estruturando documentos longos"
 ---
 

--- a/pt/more-13.md
+++ b/pt/more-13.md
@@ -1,6 +1,7 @@
 ---
 lang: "pt"
 title: "Veja mais sobre: Estruturando documentos longos"
+toc-anchor-text: "Veja mais sobre: Estruturando documentos longos"
 ---
 
 ## Criando um índice remissivo

--- a/pt/more-14.md
+++ b/pt/more-14.md
@@ -1,6 +1,7 @@
 ---
 lang: "pt"
 title: "Veja mais sobre: Trocando fontes e usando interpretadores Unicode"
+description: "Esta lição mostra um exemplo básico em Lua para usuários que querem escrever código em Lua no seu documento."
 toc-anchor-text: "Veja mais sobre: Trocando fontes e usando interpretadores Unicode"
 ---
 

--- a/pt/more-14.md
+++ b/pt/more-14.md
@@ -1,6 +1,7 @@
 ---
 lang: "pt"
 title: "Veja mais sobre: Trocando fontes e usando interpretadores Unicode"
+toc-anchor-text: "Veja mais sobre: Trocando fontes e usando interpretadores Unicode"
 ---
 
 ## Lua

--- a/pt/more-15.md
+++ b/pt/more-15.md
@@ -1,6 +1,7 @@
 ---
 lang: "pt"
 title: "Veja mais sobre: Lidando com erros"
+description: "Esta lição mostra mais alguns erros comuns no LaTeX e explica sobre cadeias de erros e erros silenciosos."
 toc-anchor-text: "Veja mais sobre: Lidando com erros"
 ---
 

--- a/pt/more-15.md
+++ b/pt/more-15.md
@@ -1,6 +1,7 @@
 ---
 lang: "pt"
 title: "Veja mais sobre: Lidando com erros"
+toc-anchor-text: "Veja mais sobre: Lidando com erros"
 ---
 
 ## Erros reportados no final de ambientes

--- a/pt/more-16.md
+++ b/pt/more-16.md
@@ -1,6 +1,7 @@
 ---
 lang: "pt"
 title: "Veja mais sobre: Acessando documentação e obtendo ajuda"
+description: "Esta lição mostra onde você pode encontrar o código do próprio LaTeX."
 toc-anchor-text: "Veja mais sobre: Acessando documentação e obtendo ajuda"
 ---
 

--- a/pt/more-16.md
+++ b/pt/more-16.md
@@ -1,6 +1,7 @@
 ---
 lang: "pt"
 title: "Veja mais sobre: Acessando documentação e obtendo ajuda"
+toc-anchor-text: "Veja mais sobre: Acessando documentação e obtendo ajuda"
 ---
 
 ## Código documentado do {{site.latex}}


### PR DESCRIPTION
Also added the text for `description` tags that had only dummy text in.