### PR TITLE
Textwidth vs linewidth

### DIFF
--- a/en/lesson-07.md
+++ b/en/lesson-07.md
@@ -45,8 +45,12 @@ the size and shape of the included images and to trim down material. Some of
 these are used a lot, so they are worth being aware of.
 
 The most obvious thing to set is the `width` or the `height` of an
-image, which are often given relative to the `\textwidth` and
-`\textheight`. LaTeX will automatically scale the image so that the aspect
+image, which are often given relative to the `\textwidth` or `\linewidth` and
+`\textheight`. The difference between `\textwidth` and `\linewidth` is subtle
+and often the result is the same. `\textwidth` is the width of the text block on
+the physical page, whereas `\linewidth` is the _current_ width, which might
+locally be different (the difference is most obvious with the class option
+`twocolumn`). LaTeX will automatically scale the image so that the aspect
 ratio stays correct.
 
 ```latex

--- a/en/lesson-07.md
+++ b/en/lesson-07.md
@@ -139,6 +139,10 @@ used in the demonstration.
 
 Explore what you can do using the `height`, `width`, `angle` and `scale` keys.
 
+Use the `width` key to set the size of a graphic relative to `\textwidth` and
+another graphic relative to `\linewidth`. Try out how they behave with or
+without the `twocolumn` option.
+
 Use `lipsum` to make a reasonably long demonstration, then try out placing
 floats using the different position specifiers. How do different
 specifiers interact?


### PR DESCRIPTION
In lesson-07 we use `\textwidth` to scale images relative to the document layout (and continue doing so in more-07 and in more-08 for tables).

I've added some text explaining that one could also use `\linewidth`, briefly explained the difference and added an exercise so that the users are inclined to explore the differences themselves.