### PR TITLE
CNAME missing

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+www.learnlatex.org


### PR DESCRIPTION
It seems, accidentally, 1b6386bbb9295c94b40fb63a07f5a7514f72ac99's removal of CNAME has not been reverted before the PR being merged to `master`, causing the site to be moved from www.learnlatex.org to learnlatex.github.io.

At present, www.learnlatex.org returns 404.

This PR reverts the mentioned commit and adds back the `CNAME` file.