### PR TITLE
Fix some minor issues with the TikZ example in the extra lesson

### DIFF
--- a/_includes/extra-01-example-tikz.md
+++ b/_includes/extra-01-example-tikz.md
@@ -2,7 +2,7 @@
 \documentclass{article}
 \usepackage[T1]{fontenc}
 \usepackage{tikz}
-\usetikzlibrary {perspective}
+\usetikzlibrary{perspective}
 
 \begin{document}
 
@@ -11,7 +11,6 @@
 -- (tpp cs:x=0,y=#2,z=#3)
 -- (tpp cs:x=#1,y=#2,z=#3)
 -- (tpp cs:x=#1,y=0,z=#3) -- cycle;
-x
 \fill[gray] (tpp cs:x=0,y=0,z=0)
 -- (tpp cs:x=0,y=0,z=#3)
 -- (tpp cs:x=0,y=#2,z=#3)
@@ -21,9 +20,9 @@ x
 -- (tpp cs:x=#1,y=0,z=#3)
 -- (tpp cs:x=#1,y=0,z=0) -- cycle;}
 \newcommand{\simpleaxes}[3]{%
-\draw[->] (-0.5,0,0) -- (#1,0,0) node[pos=1.1]{x};
-\draw[->] (0,-0.5,0) -- (0,#2,0) node[pos=1.1]{y};
-\draw[->] (0,0,-0.5) -- (0,0,#3) node[pos=1.1]{z};}
+\draw[->] (-0.5,0,0) -- (#1,0,0) node[pos=1.1]{$x$};
+\draw[->] (0,-0.5,0) -- (0,#2,0) node[pos=1.1]{$y$};
+\draw[->] (0,0,-0.5) -- (0,0,#3) node[pos=1.1]{$z$};}
 \begin{tikzpicture}[3d view]
    \simplecuboid{2}{2}{2}
    \simpleaxes{2}{2}{2}


### PR DESCRIPTION
As mentioned in the title and the commit message. There is an unnecessary and in some cases problematic "x" in the code and the "x", "y", "z" labels are not in math mode &ndash; this commit fixes them.

As I look at the examples I also noticed that the tabsize is not consistent in all lessons (some examples use 2 spaces, some use 3 spaces, some use even more, and some don't have any tab alignment). What is your opinion on this?