### PR TITLE
Babel german examples

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -86,3 +86,9 @@ defaults:
     values:
       lang: "mr"
       label: "मराठी"
+  -
+    scope:
+      path: "de"
+    values:
+      lang: "de"
+      label: "Deutsch"

--- a/de/help.md
+++ b/de/help.md
@@ -35,6 +35,19 @@ das auf der Seite so angezeigt wird:
 \usepackage[T1]{fontenc}
 
 \begin{document}
+Example text.
+\end{document}
+```
+
+bzw. ins Deutsche übersetzte Beispiele so (siehe auch [speziell fürs Deutsche
+geschriebene Lektion](language-01)):
+
+```latex
+\documentclass{article}
+\usepackage[T1]{fontenc}
+\usepackage[ngerman]{babel}
+
+\begin{document}
 Beispieltext.
 \end{document}
 ```

--- a/de/lesson-03.md
+++ b/de/lesson-03.md
@@ -29,6 +29,7 @@ Falls ein Onlinesystem genutzt werden soll, klicken Sie  bei den Beispielen auf
 ```latex
 \documentclass{article}
 \usepackage[T1]{fontenc}
+\usepackage[ngerman]{babel}
 
 \begin{document}
 Hallo Welt!
@@ -36,6 +37,11 @@ Hallo Welt!
 Dies ist ein erstes Dokument.
 \end{document}
 ```
+
+Man beachte die Zeile, in der `\usepackage[ngerman]{babel}` genutzt wird. Diese
+ist erforderlich, um LaTeX für die deutsche Sprache anzupassen. Siehe hierzu die
+[eine spätere Lektion](more-06) oder die [speziell fürs Deutsche geschriebene
+Lektion](language-01).
 
 Speichern Sie die Datei und setzen Sie sie in ein PDF-Dokument; falls Sie eine
 lokale LaTeX-Installation verwenden, hängt der dafür benötigte Knopf von Ihrer
@@ -103,6 +109,7 @@ voranstellen; wir können damit die Struktur eines Dokuments verdeutlichen:
 ```
 \documentclass[a4paper,12pt]{article} % Die Dokumentenklasse mit Optionen
 \usepackage[T1]{fontenc}
+\usepackage[ngerman]{babel}
 % Ein Kommentar in der Präambel
 \begin{document}
 % Dies ist ein Kommentar

--- a/de/lesson-04.md
+++ b/de/lesson-04.md
@@ -27,6 +27,7 @@ Betonung.)
 ```latex
 \documentclass{article}
 \usepackage[T1]{fontenc}
+\usepackage[ngerman]{babel}
 \begin{document}
 Ein wenig Text mit \emph{Hervorhebungen und \emph{geschachteltem} Inhalt}.
 
@@ -59,6 +60,7 @@ gleichbleibende Formatierung im gesamten Dokument.
 ```latex
 \documentclass{article}
 \usepackage[T1]{fontenc}
+\usepackage[ngerman]{babel}
 \begin{document}
 Hallo Welt!
 
@@ -112,6 +114,7 @@ ist, sind Listen. Zwei verbreitete Listentypen sind in LaTeX enthalten.
 ```latex
 \documentclass{article}
 \usepackage[T1]{fontenc}
+\usepackage[ngerman]{babel}
 \begin{document}
 
 Geordnet

--- a/de/lesson-05.md
+++ b/de/lesson-05.md
@@ -59,6 +59,7 @@ sich die verfügbaren Befehle bereits
 ```latex
 \documentclass{letter}
 \usepackage[T1]{fontenc}
+\usepackage[ngerman]{babel}
 \begin{document}
 
 \begin{letter}{Eine Adresse\\Einer Straße\\Jener Stadt}
@@ -120,6 +121,7 @@ der KOMA-Script Sammlung oder auf `memoir` verändert.
 ```latex
 \documentclass{article} % Hier die Dokumentklasse ändern
 \usepackage[T1]{fontenc}
+\usepackage[ngerman]{babel}
 
 \begin{document}
 

--- a/de/lesson-06.md
+++ b/de/lesson-06.md
@@ -66,6 +66,7 @@ Seitenrändern auseinandersetzt.
 \documentclass{book}
 \usepackage[T1]{fontenc}
 \usepackage[margin=2.54cm]{geometry}
+\usepackage[ngerman]{babel}
 
 \begin{document}
 Hallo Welt!
@@ -117,6 +118,7 @@ Formatierung ausgibt.
 ```latex
 \documentclass{article}
 \usepackage[T1]{fontenc}
+\usepackage[ngerman]{babel}
 
 \newcommand\kw[1]{\textbf{\itshape #1}}
 
@@ -142,6 +144,7 @@ Schlagworte in blau anstelle von fett.
 ```latex
 \documentclass{article}
 \usepackage[T1]{fontenc}
+\usepackage[ngerman]{babel}
 
 \usepackage{xcolor}
 

--- a/de/lesson-07.md
+++ b/de/lesson-07.md
@@ -18,6 +18,7 @@ Befehl `\includegraphics` zu LaTeX hinzufügt.
 ```latex
 \documentclass{article}
 \usepackage[T1]{fontenc}
+\usepackage[ngerman]{babel}
 \usepackage{graphicx}
 
 \begin{document}
@@ -57,6 +58,7 @@ kann (am auffälligsten ist der Unterschied bei Verwendung der globalen option
 ```latex
 \documentclass{article}
 \usepackage[T1]{fontenc}
+\usepackage[ngerman]{babel}
 \usepackage{graphicx}
 
 \begin{document}
@@ -77,6 +79,7 @@ Bildes.
 ```latex
 \documentclass{article}
 \usepackage[T1]{fontenc}
+\usepackage[ngerman]{babel}
 \usepackage{graphicx}
 
 \begin{document}
@@ -97,6 +100,7 @@ entstehen.
 ```latex
 \documentclass{article}
 \usepackage[T1]{fontenc}
+\usepackage[ngerman]{babel}
 \usepackage{graphicx}
 \usepackage{lipsum} % Blindtext erzeugen
 

--- a/de/lesson-08.md
+++ b/de/lesson-08.md
@@ -77,6 +77,7 @@ aber, die Quellen zu lesen.
 ```latex
 \documentclass{article}
 \usepackage[T1]{fontenc}
+\usepackage[ngerman]{babel}
 \usepackage{array}
 
 \begin{document}
@@ -98,6 +99,7 @@ richtig zu setzen. Beobachte, was in diesem Beispiel passiert:
 ```latex
 \documentclass{article}
 \usepackage[T1]{fontenc}
+\usepackage[ngerman]{babel}
 \usepackage{array}
 
 \begin{document}
@@ -125,6 +127,7 @@ Vergleiche das Resultat von oben mit folgendem Beispiel:
 ```latex
 \documentclass{article}
 \usepackage[T1]{fontenc}
+\usepackage[ngerman]{babel}
 \usepackage{array}
 
 \begin{document}
@@ -151,6 +154,7 @@ das wirklich funktioniert, ist hier die erste Tabelle mit dieser Syntax:
 ```latex
 \documentclass{article}
 \usepackage[T1]{fontenc}
+\usepackage[ngerman]{babel}
 \usepackage{array}
 
 \begin{document}
@@ -183,6 +187,7 @@ Namen sollte die vorgesehene Position ersichtlich werden:
 ```latex
 \documentclass{article}
 \usepackage[T1]{fontenc}
+\usepackage[ngerman]{babel}
 \usepackage{array}
 \usepackage{booktabs}
 
@@ -211,6 +216,7 @@ soll, muss ein Bereich angegeben werden (mit zwei identischen Zahlen).
 ```latex
 \documentclass{article}
 \usepackage[T1]{fontenc}
+\usepackage[ngerman]{babel}
 \usepackage{array}
 \usepackage{booktabs}
 
@@ -238,6 +244,7 @@ Argument in runden Klammern an beiden Enden gekürzt werden:
 ```latex
 \documentclass{article}
 \usepackage[T1]{fontenc}
+\usepackage[ngerman]{babel}
 \usepackage{array}
 \usepackage{booktabs}
 
@@ -271,6 +278,7 @@ Abstand einzufügen.
 ```latex
 \documentclass{article}
 \usepackage[T1]{fontenc}
+\usepackage[ngerman]{babel}
 \usepackage{array}
 \usepackage{booktabs}
 
@@ -310,6 +318,7 @@ möglich wäre, allerdings _nur ein einzelner Spaltentyp_.
 ```latex
 \documentclass{article}
 \usepackage[T1]{fontenc}
+\usepackage[ngerman]{babel}
 \usepackage{array}
 \usepackage{booktabs}
 
@@ -337,6 +346,7 @@ Beispiel wird dies verwendet, um die Kopfzeile der Tabelle zu zentrieren:
 ```latex
 \documentclass{article}
 \usepackage[T1]{fontenc}
+\usepackage[ngerman]{babel}
 \usepackage{array}
 \usepackage{booktabs}
 
@@ -365,6 +375,7 @@ zusammenzufassen.
 ```latex
 \document{article}
 \usepackage[T1]{fontenc}
+\usepackage[ngerman]{babel}
 \usepackage{array}
 \usepackage{booktabs}
 

--- a/de/lesson-09.md
+++ b/de/lesson-09.md
@@ -24,6 +24,7 @@ kennzeichnen. An anderer Stelle kann dann ein Verweis eingefügt werden.
 ```latex
 \documentclass{article}
 \usepackage[T1]{fontenc}
+\usepackage[ngerman]{babel}
 
 \begin{document}
 Hallo Welt!

--- a/de/lesson-10.md
+++ b/de/lesson-10.md
@@ -29,6 +29,7 @@ Es gibt zwei Formen des Mathematikmodus:
 ```latex
 \documentclass{article}
 \usepackage[T1]{fontenc}
+\usepackage[ngerman]{babel}
 
 \begin{document}
 Ein Satz mit Mathematik im Text: $y = mx + c$.
@@ -79,6 +80,7 @@ werden mit `^` und `_` ausgezeichnet.
 ```latex
 \documentclass{article}
 \usepackage[T1]{fontenc}
+\usepackage[ngerman]{babel}
 \begin{document}
 Hochgestellter Exponent $a^{b}$ und tiefgestellter Index $a_{b}$.
 \end{document}
@@ -96,6 +98,7 @@ für den griechischen Buchstaben.
 ```latex
 \documentclass{article}
 \usepackage[T1]{fontenc}
+\usepackage[ngerman]{babel}
 \begin{document}
 Etwas Mathematik: $y = 2 \sin \theta^{2}$.
 \end{document}
@@ -129,6 +132,7 @@ Besonders nützlich sind alleinstehende Gleichungen für Integrale:
 ```latex
 \documentclass{article}
 \usepackage[T1]{fontenc}
+\usepackage[ngerman]{babel}
 \begin{document}
 Ein Absatz über eine größere Gleichung
 \[
@@ -150,6 +154,7 @@ kann, [z.B. so](https://www.tug.org/TUGboat/tb41-1/tb127gregorio-math.pdf):
 ```latex
 \documentclass{article}
 \usepackage[T1]{fontenc}
+\usepackage[ngerman]{babel}
 \newcommand{\diff}{\mathop{}\!d}            % für kursiv
 % \newcommand{\diff}{\mathop{}\!\mathrm{d}} % für aufrecht
 \begin{document}
@@ -166,6 +171,7 @@ erzeugt werden. Mit dem gleichen Beispiel:
 ```latex
 \documentclass{article}
 \usepackage[T1]{fontenc}
+\usepackage[ngerman]{babel}
 \newcommand{\diff}{\mathop{}\!d}            % für kursiv
 % \newcommand{\diff}{\mathop{}\!\mathrm{d}} % für aufrecht
 \begin{document}
@@ -193,6 +199,7 @@ Beispiele als wir in dieser Lektion zeigen können.
 ```latex
 \documentclass{article}
 \usepackage[T1]{fontenc}
+\usepackage[ngerman]{babel}
 \usepackage{amsmath}
 
 \begin{document}
@@ -220,9 +227,10 @@ Das Paket stellt noch weitere nützliche Umgebungen bereit, bspw. für Matrizen.
 ```latex
 \documentclass{article}
 \usepackage[T1]{fontenc}
+\usepackage[ngerman]{babel}
 \usepackage{amsmath}
 \begin{document}
-AMS matrices.
+AMS Matrizes.
 \[
 \begin{matrix}
 a & b & c \\
@@ -261,6 +269,7 @@ könnten wir also schreiben:
 ```latex
 \documentclass{article}
 \usepackage[T1]{fontenc}
+\usepackage[ngerman]{babel}
 \begin{document}
 Die Matrix $\mathbf{M}$.
 \end{document}
@@ -279,6 +288,7 @@ oder man setzt spezifische Schriften wie `\textrm{...}`.
 ```latex
 \documentclass{article}
 \usepackage[T1]{fontenc}
+\usepackage[ngerman]{babel}
 \usepackage{amsmath}
 \begin{document}
 

--- a/de/lesson-11.md
+++ b/de/lesson-11.md
@@ -24,6 +24,7 @@ stattdessen eine "Leerzeile" zwischen den Absätzen auszugeben. Dies kann mit de
 ```latex
 \documentclass{article}
 \usepackage[T1]{fontenc}
+\usepackage[latin]{babel} % lipsum erzeugt pseudolateinischen Text
 \usepackage[parfill]{parskip}
 \usepackage{lipsum} % nur für Blindtext
 \begin{document}
@@ -59,6 +60,7 @@ horizontaler oder vertikaler Abstand benötigt. Hierzu können `\hspace` und
 ```latex
 \documentclass{article}
 \usepackage[T1]{fontenc}
+\usepackage[ngerman]{babel}
 \begin{document}
 Etwas Text \hspace{1cm} mehr Text.
 
@@ -82,6 +84,7 @@ und `\textsc`.
 ```latex
 \documentclass{article}
 \usepackage[T1]{fontenc}
+\usepackage[ngerman]{babel}
 \begin{document}
 Hier ein wenig Spaß mit Schrift: \textbf{fett}, \textit{kursiv},
 \textrm{Roman}, \textsf{serifenlos}, \texttt{dicktengleich} und
@@ -99,6 +102,7 @@ auch `{...}` verwenden, um explizit eine Gruppe zu bilden.
 ```latex
 \documentclass{article}
 \usepackage[T1]{fontenc}
+\usepackage[ngerman]{babel}
 \begin{document}
 Normaler Text.
 
@@ -121,6 +125,7 @@ beachte, dass wir einen expliziten `\par` (Absatzende) verwenden.
 ```latex
 \documentclass{article}
 \usepackage[T1]{fontenc}
+\usepackage[ngerman]{babel}
 \begin{document}
 Normaler Text.
 

--- a/de/lesson-12.md
+++ b/de/lesson-12.md
@@ -126,6 +126,7 @@ Die Grundstruktur der Eingabe wird in diesem Beispiel gezeigt.
 ```latex
 \documentclass{article}
 \usepackage[T1]{fontenc}
+\usepackage[ngerman]{babel}
 \usepackage{natbib}
 
 \begin{document}
@@ -168,6 +169,7 @@ einige neue Befehle.
 ```latex
 \documentclass{article}
 \usepackage[T1]{fontenc}
+\usepackage[ngerman]{babel}
 \usepackage[style=authoryear]{biblatex}
 \addbibresource{learnlatex.bib}
 

--- a/de/lesson-13.md
+++ b/de/lesson-13.md
@@ -50,6 +50,7 @@ Ein langes Dokument könnte also folgendermaßen aufgebaut sein:
 ```latex
 \documentclass{book}
 \usepackage[T1]{fontenc}
+\usepackage[ngerman]{babel}
 \usepackage{biblatex}
 \addbibresource{biblatex-examples.bib}
 

--- a/de/lesson-15.md
+++ b/de/lesson-15.md
@@ -55,6 +55,7 @@ TeX-System, wie etwa TeX Live oder MiKTeX, zu installieren.
 ```latex
 \documentclass{article}
 \usepackage[T1]{fontenc}
+\usepackage[ngerman]{babel}
 
 \newcommand\mycommand{\textbold{hmmm}}
 
@@ -173,6 +174,7 @@ installiert werden muss.
 ```latex
 \documentclass{article}
 \usepackage[T1]{fontenc}
+\usepackage[ngerman]{babel}
 
 \begin{document}
 

--- a/de/lesson-16.md
+++ b/de/lesson-16.md
@@ -92,6 +92,7 @@ Wie erstellt man ein MWE? Am einfachsten ist, man beginnt in etwa so:
 ```latex
 \documentclass{article}
 \usepackage[T1]{fontenc}
+\usepackage[ngerman]{babel}
 \begin{document}
 Text
 \end{document}

--- a/de/more-01.md
+++ b/de/more-01.md
@@ -2,5 +2,27 @@
 layout: "lesson"
 lang: "de"
 title: "Mehr zu: Was ist LaTeX und wie funktioniert es?"
+description: "Diese Lektion klärt weitere Einzelheiten der Geschichte LaTeXs und anderer Formate."
+toc-anchor-text: "Mehr zu: Was ist LaTeX und wie funktioniert es?"
 ---
-Translation to be added _after_ English text completed.
+
+Das Wort 'LaTeX' besteht eigentlich aus zwei Komponenten, 'La' und 'TeX'. Im
+Folgenden wollen wir kurz erklären, woher diese stammen.
+
+TeX wurde ursprünglich vom Stanford-Professor Donald Knuth entwickelt. Knuth
+erlangte für seine Buchreihe _The Art of Computer Programming_ (auch bekannt als
+TAOCP) große Bekanntheit. Im Jahr 1973 wurde eine neue Edition erstellt; zur
+selben Zeit wechselte die Satz-Industrie vom traditionellen Buchdruck mit
+Bleilettern zu Fotosatz. Donald Knuth war mit der Qualität des Drucks
+unzufrieden und beschloss deshalb, sein eigenes Textsatzsystem zu
+implementieren.
+
+Im Mai 1977 begann die Entwicklung von TeX.
+
+Das ursprüngliche TeX war in der Nutzung kompliziert, Donald Knuth selbst
+verwendete schon verschiedene Makros, um sein Buch zu setzen. Leslie Lamport,
+heute für Microsoft tätig, entwarf ein eigenes Set an Makros, die den Umgang mit
+TeX vereinfachten. Er nannte es 'LaTeX'.
+
+Heute ist LaTeX die verbreitetste Eingabemethode für TeX. Eine Alternative ist
+[ConTeXt](https://www.contextgarden.net/).

--- a/de/more-04.md
+++ b/de/more-04.md
@@ -14,6 +14,7 @@ Befehle, die die 'Metadaten' definieren, und einer, um sie zu nutzen.
 ```latex
 \documentclass{article}
 \usepackage[T1]{fontenc}
+\usepackage[ngerman]{babel}
 \begin{document}
 \author{E.~I.~N.~Anderer \and D.~Keinspeck}
 \title{Dinge, die ich tat}
@@ -46,6 +47,7 @@ eine weniger weit verbreitete zur Verfügung: beschreibende Listen.
 ```latex
 \documentclass{article}
 \usepackage[T1]{fontenc}
+\usepackage[ngerman]{babel}
 \begin{document}
 
 \begin{description}

--- a/de/more-05.md
+++ b/de/more-05.md
@@ -27,6 +27,7 @@ verbreitetere der beiden ist, hier ein Beispiel in `beamer`:
 ```latex
 \documentclass{beamer}
 \usepackage[T1]{fontenc}
+\usepackage[ngerman]{babel}
 \begin{document}
 
 \begin{frame}
@@ -64,6 +65,7 @@ Klasse erreichen, die automatisch die Seitengröße an die Inhalte anpasst.
 ```latex
 \documentclass{standalone}
 \usepackage[T1]{fontenc}
+\usepackage[ngerman]{babel}
 \begin{document}
 Ein einfaches Dokument: Das wird eine ziemlich kleine Box!
 \end{document}

--- a/de/more-06.md
+++ b/de/more-06.md
@@ -90,6 +90,7 @@ mit Blau als Standardwert.
 ```
 \documentclass{article}
 \usepackage[T1]{fontenc}
+\usepackage[ngerman]{babel}
 
 \usepackage{xcolor}
 
@@ -117,6 +118,7 @@ Wiederholen wir obiges Beispiel allerdings mit `\NewDocumentCommand`.
 ```
 \documentclass{article}
 \usepackage[T1]{fontenc}
+\usepackage[ngerman]{babel}
 
 \usepackage{xparse} % Nur für ältere LaTeX-Versionen notwendig
 \usepackage{xcolor}

--- a/de/more-07.md
+++ b/de/more-07.md
@@ -71,6 +71,7 @@ werden. Das `float` Paket unterstützt genau das.
 ```latex
 \documentclass{article}
 \usepackage[T1]{fontenc}
+\usepackage[ngerman]{babel}
 \usepackage{graphicx}
 \usepackage{lipsum}  % Blindtext
 \usepackage{float}
@@ -105,6 +106,7 @@ definiert einen Befehl, um neue Gleitumgebungsarten zu erstellen.
 ```latex
 \documentclass{article}
 \usepackage[T1]{fontenc}
+\usepackage[ngerman]{babel}
 \usepackage{graphicx}
 \usepackage{lipsum}  % Blindtext
 \usepackage{trivfloat}

--- a/de/more-08.md
+++ b/de/more-08.md
@@ -29,6 +29,7 @@ das Folgende genutzt werden:
 ```latex
 \documentclass{article}
 \usepackage[T1]{fontenc}
+\usepackage[ngerman]{babel}
 \usepackage{array}
 \usepackage{booktabs}
 
@@ -59,6 +60,7 @@ Zelle zu verändern.
 ```latex
 \documentclass{article}
 \usepackage[T1]{fontenc}
+\usepackage[ngerman]{babel}
 \usepackage{array}
 \usepackage{booktabs}
 
@@ -89,6 +91,7 @@ beiden äußeren Rändern der Tabelle erhalten und zwischen zwei Spalten
 ```latex
 \documentclass{article}
 \usepackage[T1]{fontenc}
+\usepackage[ngerman]{babel}
 \usepackage{array}
 
 \setlength\tabcolsep{1cm}
@@ -113,6 +116,7 @@ wird:
 ```latex
 \documentclass{article}
 \usepackage[T1]{fontenc}
+\usepackage[ngerman]{babel}
 \usepackage{array}
 
 \begin{document}
@@ -136,6 +140,7 @@ des Argument in der Mitte des Abstands zwischen Spalten _hinzugefügt_ wird.
 ```latex
 \documentclass{article}
 \usepackage[T1]{fontenc}
+\usepackage[ngerman]{babel}
 \usepackage{array}
 
 \begin{document}
@@ -158,6 +163,7 @@ Manchmal muss man senkrechte Linien verwenden.
 ```latex
 \documentclass{article}
 \usepackage[T1]{fontenc}
+\usepackage[ngerman]{babel}
 \usepackage{array}
 
 \begin{document}
@@ -191,6 +197,7 @@ und `l` beeinflusst werden.
 ```latex
 \documentclass{article}
 \usepackage[T1]{fontenc}
+\usepackage[ngerman]{babel}
 \usepackage{array}
 \usepackage{booktabs}
 
@@ -216,6 +223,7 @@ Ein einfaches Beispiel mit zwei ausgerichteten Spalten wäre:
 ```latex
 \documentclass{article}
 \usepackage[T1]{fontenc}
+\usepackage[ngerman]{babel}
 \usepackage{booktabs}
 \usepackage{siunitx}
 
@@ -263,6 +271,7 @@ wird.
 ```latex
 \documentclass{article}
 \usepackage[T1]{fontenc}
+\usepackage[ngerman]{babel}
 \usepackage{array}
 \begin{document}
 
@@ -306,6 +315,7 @@ entspricht der Verwendung von `p{...}` mit automatisch gewählter Breite.
 ```latex
 \documentclass{article}
 \usepackage[T1]{fontenc}
+\usepackage[ngerman]{babel}
 \usepackage{tabularx}
 \begin{document}
 
@@ -356,6 +366,8 @@ Seitenumbrüche erlauben. Wir zeigen hier das `longtable` Paket:
 
 ```latex
 \documentclass{article}
+\usepackage[T1]{fontenc}
+\usepackage[ngerman]{babel}
 \usepackage[paperheight=8cm,paperwidth=8cm]{geometry}
 \usepackage{array}
 \usepackage{longtable}
@@ -406,6 +418,7 @@ einfaches Beispiel sei allerdings hier gezeigt.
 ```latex
 \documentclass{article}
 \usepackage[T1]{fontenc}
+\usepackage[ngerman]{babel}
 \usepackage{array}
 \usepackage{threeparttable}
 
@@ -448,9 +461,9 @@ Schriftgrad weniger schmal sind.
 ```latex
 \documentclass[a4paper]{article}
 \usepackage[T1]{fontenc}
+\usepackage[ngerman]{babel}
 \usepackage{array}
 \usepackage{ragged2e}
-\usepackage[ngerman]{babel}
 
 \begin{document}
 \begin{table}
@@ -503,6 +516,7 @@ Umgebungen in mehrere Zeilen aufgeteilt werden.
 ```latex
 \documentclass{article}
 \usepackage[T1]{fontenc}
+\usepackage[ngerman]{babel}
 \usepackage{array}
 \usepackage{booktabs}
 
@@ -528,6 +542,7 @@ zentriert oder unten ausgerichtet, verwendet wird es wie folgt:
 ```latex
 \documentclass{article}
 \usepackage[T1]{fontenc}
+\usepackage[ngerman]{babel}
 \usepackage{array}
 \usepackage{booktabs}
 
@@ -566,6 +581,7 @@ Das folgende Beispiel zeigt die Verwendung von `\extrarowheight`.
 ```latex
 \documentclass[a4paper]{article}
 \usepackage[T1]{fontenc}
+\usepackage[ngerman]{babel}
 \usepackage{array}
 
 \begin{document}

--- a/de/more-09.md
+++ b/de/more-09.md
@@ -15,6 +15,7 @@ geladen werden.
 ```latex
 \documentclass{article}
 \usepackage[T1]{fontenc}
+\usepackage[ngerman]{babel}
 \usepackage[hidelinks]{hyperref}
 
 \begin{document}

--- a/de/more-10.md
+++ b/de/more-10.md
@@ -49,6 +49,7 @@ Gleichungen mit der Ausrichtung am Relationssymbol.
 ```latex
 \documentclass{article}
 \usepackage[T1]{fontenc}
+\usepackage[ngerman]{babel}
 \usepackage{amsmath}
 \begin{document}
 Ausgerichtete Gleichungen
@@ -66,6 +67,7 @@ einen größeren Term in einer größeren Gleichung zu setzen. Beispielsweise si
 ```latex
 \documentclass{article}
 \usepackage[T1]{fontenc}
+\usepackage[ngerman]{babel}
 \usepackage{amsmath}
 \begin{document}
 Aligned:
@@ -91,6 +93,7 @@ Zeile auszurichten; vergleiche folgende Elemente einer Liste.
 ```latex
 \documentclass{article}
 \usepackage[T1]{fontenc}
+\usepackage[ngerman]{babel}
 \usepackage{amsmath}
 \begin{document}
 \begin{itemize}
@@ -188,6 +191,7 @@ kleines Beispiel soll aber nicht vorenthalten werden.
 ```latex
 % !TEX lualatex
 \documentclass[a4paper]{article}
+\usepackage[ngerman]{babel}
 \usepackage{unicode-math}
 \setmainfont{TeX Gyre Pagella}
 \setmathfont{TeX Gyre Pagella Math}

--- a/de/more-11.md
+++ b/de/more-11.md
@@ -15,6 +15,7 @@ sollte LaTeX die Einzüge automatisch regeln.
 ```latex
 \documentclass{article}
 \usepackage[T1]{fontenc}
+\usepackage[ngerman]{babel}
 \begin{document}
 Ein kleiner Absatz, der ein wenig ausgeschmückt wird, damit die Auswirkungen
 auch wirklich gesehen werden können!

--- a/de/more-13.md
+++ b/de/more-13.md
@@ -20,6 +20,7 @@ verwendet auch eine Hilfsdatei. Glücklicherweise ist der Vorgang durch das
 ```latex
 \documentclass{article}
 \usepackage[T1]{fontenc}
+\usepackage[ngerman]{babel}
 \usepackage{imakeidx}
 \makeindex
 \begin{document}

--- a/de/more-15.md
+++ b/de/more-15.md
@@ -62,11 +62,12 @@ zerbrechen und sich auf das Beheben des ersten Fehlers konzentrieren.
 ```latex
 \documentclass{article}
 \usepackage[T1]{fontenc}
+\usepackage[ngerman]{babel}
 
 \begin{document}
-Text_word  $\alpha + \beta$.
+Text_Wort  $\alpha + \beta$.
 
-More text.
+Mehr Text.
 \end{document}
 ```
 
@@ -112,10 +113,11 @@ erzeugt; um den Fehler zu sehen, muss `%!TeX log` hinzugefügt werden.
 ```latex
 \documentclass{article}
 \usepackage[T1]{fontenc}
+\usepackage[ngerman]{babel}
 
 \begin{document}
 
- Text {\large eineg großer Text) normale Größe?
+ Text {\large etwas großer Text) normale Größe?
 
 \end{document}
 ```


### PR DESCRIPTION
This PR will add `babel` to the German examples. I also translated the missing `more-01.md` and made the required adjustments to `help.md`.