### PR TITLE
Change style of pre so that pre and ACE editor share the same text style

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+www.learnlatex.org

--- a/CNAME
+++ b/CNAME
@@ -1,2 +1,0 @@
-www.learnlatex.org
-

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -987,9 +987,11 @@ pre {
   box-shadow: inset 0 0.125rem 0.125rem 0 rgba(50, 50, 50, 0.5);
   overflow: auto;
   padding: 0 .4rem;
-  font-family: var(--font_default-mono-regular);
-  font-size: .8rem;
   background-color: #F5F5F5;
+  code {
+    font-family: var(--font_default-mono-regular);
+    font-size: .8rem;
+  }
 }
 
 

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -987,9 +987,9 @@ pre {
   box-shadow: inset 0 0.125rem 0.125rem 0 rgba(50, 50, 50, 0.5);
   overflow: auto;
   padding: 0 .4rem;
-  background-color: #F5F5F5;
   font-family: var(--font_default-mono-regular);
   font-size: .8rem;
+  background-color: #F5F5F5;
 }
 
 

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -991,6 +991,7 @@ pre {
   code {
     font-family: var(--font_default-mono-regular);
     font-size: .8rem;
+    line-height: 1.2rem;
   }
 }
 

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -988,7 +988,9 @@ pre {
   overflow: auto;
   padding: 0 .4rem;
   background-color: #F5F5F5;
-  }
+  font-family: var(--font_default-mono-regular);
+  font-size: .8rem;
+}
 
 
 


### PR DESCRIPTION
Currently, ACE editor and `.noedit` code blocks have different text styles. Looking at the following screenshots (Ubuntu, Firefox), I see the following differences:

|style|ACE editor|`.noedit` code blocks|
|---|---|---|
|font family|Noto Mono|default mono font (Ubuntu Mono)|
|font size|0.8 rem|16 px|
|line height|1.2 rem|22.4 px|

This PR makes `.noedit` code blocks follow ACE's currently *default* styles.

![image](https://user-images.githubusercontent.com/44609036/114299830-9a31a600-9ae7-11eb-8942-6bea835706d2.png)  
![image](https://user-images.githubusercontent.com/44609036/114299852-b33a5700-9ae7-11eb-8f97-dd5f5148055d.png)
