### PR TITLE
Spanish translation of privacy.md

### DIFF
--- a/es/licenses.md
+++ b/es/licenses.md
@@ -2,7 +2,7 @@
 layout: "page"
 lang: "es"
 title: Licencias
-permalink: /en/licenses
+permalink: /es/licenses
 ---
 
 # Licencias

--- a/es/privacy.md
+++ b/es/privacy.md
@@ -1,0 +1,34 @@
+---
+layout: "page"
+lang: "es"
+title: Política de Privacidad
+permalink: /es/privacy
+---
+# Política de Privacidad
+
+## Datos del usuario
+
+LearnLaTeX.org ni require registrarse, ni conserva datos personales del usuario.
+Al estar el sitio web hospedado en GitHub Pages, las personas que actualizan el 
+sitio web no tienen acceso a ninguna información sobre la actividad de los usuarios. 
+El sitio web no usa ningún tipo de servicio de tracking como Google Analytics.
+
+## Cookies
+
+Por defecto, el sitio web no usa cookies. Como se comenta en la
+sección [Configuración del sitio web](settings), los usuarios pueden
+opcionalmente aceptar cookies y conservar sus preferencias. Las cookies que guardan
+las preferencias del usuario (como el motor de TeX por defecto) _no_ son generadas por 
+LearnLatex.org, ni son transmitidas a este sitio web. Estas cookies son generadas y
+guardadas por el JavaScript que se ejecuta en el explorator del usuario.
+
+## Sitios Web Externos
+
+Si utiliza la opción de ejecutar los ejemplos en un servicio en línea, entonces
+los datos del editor que esté usando serán transmitidos, vía una solicitud https POST, 
+al servicio seleccionado y la política de privacidad pasará a ser la correspondiente
+a este servicio externo. Los siguientes enlaces le permiten acceder a la
+política de privacidad de los servicios en línea más utilizados:
+
+* [Overleaf](https://www.overleaf.com/legal)
+* [TeXLive.net](https://davidcarlisle.github.io/latexcgi/privacy)


### PR DESCRIPTION
Fix a typo in the heading of es\licenses.md
Spanish translation of the privacy.md file