### PR TITLE
Update german

### DIFF
--- a/_data/translations.yml
+++ b/_data/translations.yml
@@ -127,7 +127,7 @@ navigational-elements_help:
   mr: "मदत"
   ca: "Ajuda"
 navigational-elements_settings:
-  de: "Settings"
+  de: "Einstellungen"
   en: "Settings"
   es: "Configuración"
   fr: "Paramètres"
@@ -163,7 +163,7 @@ navigational-elements_licenses:
   mr: "परवाने"
   ca: "Llicències"
 navigational-elements_privacy:
-  de: "Privacy"
+  de: "Datenschutz"
   en: "Privacy"
   es: "Privacidad"
   fr: "Confidentialité"

--- a/de/privacy.md
+++ b/de/privacy.md
@@ -1,34 +1,34 @@
 ---
 layout: "page"
 lang: "de"
-title: Privacy Policy
+title: Datenschutzerklärung
 permalink: /de/privacy
 ---
-# Privacy Policy
+# Datenschutzerklärung
 
-## User Data
+## Nutzerdaten
 
-LearnLaTeX.org requires no user login and stores no user-specifc data.
-As the site is hosted at GitHub Pages, no information at all is available
-to the site maintainers on user activity. The site does not use any tracking
-service such as Google Analytics.
+LearnLaTeX.org benötigt keinen Login und speichert keine benutzerspezifischen
+Daten. Da die Seite auf GitHub Pages gehostet wird, sind keine Informationen zur
+Nutzeraktivität den Betreibern zugänglich. Die Seite verwendet keine
+Trackingservices wie bspw. Google Analytics.
 
 ## Cookies
 
-By default the site does not use any cookies. As documented on the
-[Site Settings](settings) page, users may optionally accept cookies
-and store preferences. The cookies storing preferences (such as
-default TeX engine) are _not_ generated or transmitted to the
-LearnLaTeX.org site but are generated and stored by the JavaScript
-running within the user's browser.
+Standardmäßig werden keine Cookies verwendet. Wie bei den
+[Seiteneinstellungen](settings) beschrieben, können Nutzer optional Cookies
+zustimmen, um die Einstellungen (z.B. die voreingestellte TeX-Engine) zu
+speichern. Die Einstellungs-Cookies werden _nicht_ an LearnLaTeX.org
+übermittelt, sondern lokal durch das im Browser des Nutzers laufende JavaScript
+erzeugt und gespeichert.
 
-## External Sites
+## Externe Seiten
 
-If the option to run examples at an online service is used, then the
-data in the current editor will be transmitted via an https POST
-request to the relevant service and be subject to the privacy policy
-of that external service. The following links apply to the services
-currently used.
+Falls die Option, Beispiele bei anderen Onlineservices auszuführen, genutzt
+wird, werden die momentanen Daten im Editor mittels einer https POST Anforderung
+den entsprechenden Services übermittelt und sind Gegenstand der
+Datenschutzerklärung dieses externen Services. Die folgenden Links führen zu den
+entsprechenden Erklärungen der momentan genutzten Services:
 
 * [Overleaf](https://www.overleaf.com/legal)
 * [TeXLive.net](https://davidcarlisle.github.io/latexcgi/privacy)

--- a/de/settings.md
+++ b/de/settings.md
@@ -1,39 +1,46 @@
 ---
 layout: "page"
 lang: "de"
-title: Site Settings
+title: Seiteneinstellungen
 permalink: /de/settings
 ---
-# Site Settings (User Preferences) (DE)
+# Seiteneinstellungen (Benutzereinstellungen) (DE)
 
-## Accept or Delete Cookies
+## Cookies akzeptieren oder löschen
 
-Cookies are small pieces of data that are stored by your browser.
-By default no cookies are used by this site, but any options set on
-this page are stored in cookies.
+Cookies sind kleine Datensätze, die im Browser des Benutzers gespeichert werden.
+Standardmäßig werden keine Cookies von dieser Seite genutzt, allerdings werden
+alle Einstellungen, die hier getroffen werden, in Cookies gespeichert.
 
-Accept cookies here to enable the use of cookies on this site and to
-enable the menu options below.
+Um Einstellung im folgenden Menü zu treffen und Cookies zu speichern, müssen
+Cookies akzeptiert werden.
 
 
 {% include settings-accept.html 
-   accept="Accept Cookies"
-   reset= "Reset: Delete All Cookies"
+   accept="Cookies akzeptieren"
+   reset= "Zurücksetzen: Alle Cookies löschen"
 %}
 
-## Default Return
-The `return` form parameter that TeXLive.net should use in the absence of a setting via `% !TeX` comments in the example.
+## Standardrückgabe
+
+Die Form der Rückgabe über den `return` Parameter, die TeXLive.net benutzen
+soll, wenn keine direkte Wahl über `% !TeX` Kommentare im Beispiel getroffen
+wird.
 
 {% include settings-return.html %}
 
 
-## Default Engine
-The `engine` form parameter that TeXLive.net or Overleaf should use in the absence of a setting via `% !TeX` comments in the example. (`-dev` and `context` options should not be used at Overleaf.)
+## Standardengine
+
+Die `engine` die von TeXLive.net oder Overleaf benutzt werden soll, wenn keine
+direkte Wahl über `% !TeX` Kommentare im Beispiel getroffen wird. (Die `-dev`
+und `context` Optionen sollten nicht mit Overleaf verwendet werden.)
 
 {% include settings-engine.html %}
 
 
-## Editor Theme
-The theme used by the embedded ACE editor.
+## Editorthema
+
+Das Thema, welches der eingebettete ACE-Editor verwendet.
 
 {% include settings-acetheme.html %}


### PR DESCRIPTION
This PR adds a few files which were missing from the German translation up to now. Those are:

- `privacy`
- `settings`

Also, a few of the navigation strings were missing in `translations.yml`.