### PR TITLE
TLC2 -> TLC3  (except for French language)

### DIFF
--- a/ca/lesson-16.md
+++ b/ca/lesson-16.md
@@ -36,7 +36,7 @@ Aquesta [pàgina web](https://texdoc.org/) funciona de manera similar a la utili
 
 Hi ha diversos llibres disponibles que et poden ajudar per aprendre LaTeX. Com a principiant, pots aprendre molt a partir d'una guia estructurada per a principiants, doncs pots trobar-hi molts més detalls dels que cobrim en aquest tutorial. També podràs accedir a un manual de referència amb molt més detall i recomanacions.
 
-L'equip de LaTeX té una [llista de llibres](https://www.latex-project.org/help/books/) escrits pels seus membres. El més destacat és la [guia oficial de Lamport](https://www.informit.com/store/latex-a-document-preparation-system-9780201529838) i el detallat [LaTeX Companion](https://www.informit.com/store/latex-companion-9780201362992).
+L'equip de LaTeX té una [llista de llibres](https://www.latex-project.org/help/books/) escrits pels seus membres. El més destacat és la [guia oficial de Lamport](https://www.informit.com/store/latex-a-document-preparation-system-9780201529838) i el detallat [LaTeX Companion 3rd edition](https://www.informit.com/store/latex-companion-parts-i-ii-3rd-edition-9780138166489).
 
 Altres llibres que et poden ajudar a aprendre LaTeX són
 

--- a/de/lesson-16.md
+++ b/de/lesson-16.md
@@ -56,7 +56,7 @@ Büchern](https://www.latex-project.org/help/books/), die hauptsächlich von
 Teammitgliedern geschrieben wurden. Erwähnt werden sollte [Lamports offizielle
 Anleitung](https://www.informit.com/store/latex-a-document-preparation-system-9780201529838)
 und der umfassende
-[LaTeX Companion](https://www.informit.com/store/latex-companion-9780201362992).
+[LaTeX Companion 3rd edition](https://www.informit.com/store/latex-companion-parts-i-ii-3rd-edition-9780138166489).
 
 Andere Bücher zum Lernen von LaTeX wären
 

--- a/en/lesson-16.md
+++ b/en/lesson-16.md
@@ -54,7 +54,7 @@ The LaTeX team have [a list of books](https://www.latex-project.org/help/books/)
 largely written by members. The most notable are [Lamport's official
 guide](https://www.informit.com/store/latex-a-document-preparation-system-9780201529838)
 and the comprehensive
-[LaTeX Companion](https://www.informit.com/store/latex-companion-9780201362992).
+[LaTeX Companion 3rd edition](https://www.informit.com/store/latex-companion-parts-i-ii-3rd-edition-9780138166489).
 
 Other books aimed at learning LaTeX include
 

--- a/es/lesson-16.md
+++ b/es/lesson-16.md
@@ -58,7 +58,7 @@ El equipo de LaTeX dispone de [una lista de libros](https://www.latex-project.or
 escritos fundamentalmente por los miembros del equipo. Los más destacados son [Lamport's official
 guide](https://www.informit.com/store/latex-a-document-preparation-system-9780201529838)
 y el detallado
-[LaTeX Companion](https://www.informit.com/store/latex-companion-9780201362992).
+[LaTeX Companion 3rd edition](https://www.informit.com/store/latex-companion-parts-i-ii-3rd-edition-9780138166489).
 
 Otros libros dedicados al aprendizaje de LaTeX:
 

--- a/it/lesson-16.md
+++ b/it/lesson-16.md
@@ -74,7 +74,7 @@ scritti per lo più dai suoi membri.
 I più notevoli sono 
 [la guida ufficiale di Lamport](https://www.informit.com/store/latex-a-document-preparation-system-9780201529838)
 e l'esauriente
-[The LaTeX Companion](https://tex.stackexchange.com/questions/612573/the-latex-companion-3rd-edition), arrivato alla terza edizione.
+[LaTeX Companion 3rd edition](https://www.informit.com/store/latex-companion-parts-i-ii-3rd-edition-9780138166489), arrivato alla terza edizione.
 
 Altri libri mirati all'apprendimento di LaTeX sono i seguenti.
 

--- a/lt/lesson-16.md
+++ b/lt/lesson-16.md
@@ -60,7 +60,7 @@ knygų](https://www.latex-project.org/help/books/), didžiumą kurių parašė
 komandos nariai.  Žymiausios iš jų yra [oficialus LaTeX
 vadovas](https://www.informit.com/store/latex-a-document-preparation-system-9780201529838),
 parašytas LaTeX formato pradininko Lamport'o ir gal kiek jau pasenęs, ir
-visapusiška knyga [LaTeX Companion](https://www.informit.com/store/latex-companion-9780201362992).
+visapusiška knyga [LaTeX Companion 3rd edition](https://www.informit.com/store/latex-companion-parts-i-ii-3rd-edition-9780138166489).
 
 Kitos knygos, skirtos mokytis LaTeX, yra
 

--- a/mr/lesson-16.md
+++ b/mr/lesson-16.md
@@ -60,7 +60,7 @@ toc-description: "दस्तऐवजीकरण व मदत मिळव�
 लिहिलेली
 [लाटेक्-हस्तपुस्तिका](https://www.informit.com/store/latex-a-document-preparation-system-9780201529838) 
 व
-[The LaTeX Companion](https://www.informit.com/store/latex-companion-9780201362992) हे
+[LaTeX Companion 3rd edition](https://www.informit.com/store/latex-companion-parts-i-ii-3rd-edition-9780138166489) हे
 पुस्तक.
 
 ह्यांव्यतिरिक्त इतर पुस्तके -

--- a/pt/lesson-16.md
+++ b/pt/lesson-16.md
@@ -58,7 +58,7 @@ O time LaTeX tem uma [lista de livros](https://www.latex-project.org/help/books)
 escrita em sua maioria pelos membros.  Os mais notáveis são o
 [guia oficial de Lamport](https://www.informit.com/store/latex-a-document-preparation-system-9780201529838)
 e o abrangente
-[LaTeX Companion](https://www.informit.com/store/latex-companion-9780201362992).
+[LaTeX Companion 3rd edition](https://www.informit.com/store/latex-companion-parts-i-ii-3rd-edition-9780138166489).
 
 Outros livros focados no aprendizado de LaTeX incluem:
 

--- a/tr/lesson-16.md
+++ b/tr/lesson-16.md
@@ -56,7 +56,7 @@ The LaTeX team have [a list of books](https://www.latex-project.org/help/books/)
 largely written by members. The most notable are [Lamport's official
 guide](https://www.informit.com/store/latex-a-document-preparation-system-9780201529838)
 and the comprehensive
-[LaTeX Companion](https://www.informit.com/store/latex-companion-9780201362992).
+[LaTeX Companion 3rd edition](https://www.informit.com/store/latex-companion-parts-i-ii-3rd-edition-9780138166489).
 
 Other books aimed at learning LaTeX include
 

--- a/vi/lesson-16.md
+++ b/vi/lesson-16.md
@@ -61,7 +61,7 @@ như vậy thường cung cấp nhiều thông tin hơn những gì ta nói tớ
 bởi các thành viên. Hai cuốn đáng chú ý nhất là [Hướng dẫn sử dụng LaTeX của
 Lamport](https://www.informit.com/store/latex-a-document-preparation-system-9780201529838)
 (ta còn nhớ trong [bài này](more-01) rằng Lamport chính là cha đẻ của LaTeX),
-hay [LaTeX Companion](https://www.informit.com/store/latex-companion-9780201362992).
+hay [LaTeX Companion 3rd edition](https://www.informit.com/store/latex-companion-parts-i-ii-3rd-edition-9780138166489).
 
 Một vài cuốn sách khác có nội dung tương tự:
 


### PR DESCRIPTION
Link to TLC3 not TLC2 in module 16. Not done for French as the text is different there (but /fr should be updated too, eventually)