### PR TITLE
Link to TLC3 not TLC2 in module 16, in French version.

### DIFF
--- a/fr/lesson-16.md
+++ b/fr/lesson-16.md
@@ -92,9 +92,8 @@ de vous tourner vers des documentations en anglais.
 
 L'équipe LaTeX propose [une liste de livres](https://www.latex-project.org/help/books/)
 en grande partie écrits par ses membres. Les plus remarquables sont
-[le guide officiel par Leslie Lamport](https://www.pearson.com/us/higher-education/program/Lamport-La-Te-X-A-Document-Preparation-System-2nd-Edition/PGM159713.html)
-et le [LaTeX Companion](https://www.pearson.ch/Informatik/Addison-Wesley/EAN/9780201362992/LaTeX-Companion-The),
-également [disponible en français](https://www.leslibraires.fr/livre/915590-latex-companion-frank-mittelbach-michel-goossens-pearson).
+[le guide officiel par Leslie Lamport](https://www.informit.com/store/latex-a-document-preparation-system-9780201529838)
+et le [LaTeX Companion (3e édition)](https://www.informit.com/store/latex-companion-parts-i-ii-3rd-edition-9780138166489) (la [version française](https://www.leslibraires.fr/livre/915590-latex-companion-frank-mittelbach-michel-goossens-pearson) est une traduction de la deuxième édition, datant de 2004).
 
 
 ## Foire aux questions


### PR DESCRIPTION
TLC link changed in French version.