### PR TITLE
Call ~ tilde

### DIFF
--- a/en/lesson-09.md
+++ b/en/lesson-09.md
@@ -73,10 +73,10 @@ Run LaTeX one more time and you'll be all set.
 (Usually while writing you will run LaTeX several times anyway,
 so in practice this is not a bother.)
 
-Notice the tie (`~`) characters before the references.
+Notice the tilde (`~`) characters before the references.
 You don't want a line break between `subsection` and its number, or
 between `equation` and its number.
-Putting in a tie means LaTeX won't break the line there.
+Putting in a tilde means LaTeX won't break the line there.
 
 ## Where to put `\label`
 

--- a/tr/lesson-09.md
+++ b/tr/lesson-09.md
@@ -68,10 +68,10 @@ Run LaTeX one more time and you'll be all set.
 (Usually while writing you will run LaTeX several times anyway,
 so in practice this is not a bother.)
 
-Notice the tie (`~`) characters before the references.
+Notice the tilde (`~`) characters before the references.
 You don't want a line break between `subsection` and its number, or
 between `equation` and its number.
-Putting in a tie means LaTeX won't break the line there.
+Putting in a tilde means LaTeX won't break the line there.
 
 ## Where to put `\label`
 


### PR DESCRIPTION
In the rest of the document and also according to the Unicode standard, Wikipedia, and other sources the character ~ is called tilde, whereas tie is the name of a different set of characters.