### PR TITLE
Author roles

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -10,6 +10,7 @@ The following people have made contributions to learnlatex.org:
  
 | Name                 | Role |
 |---                   |---|
+| Takuto Asakura       | _Japanese translation _ |
 | Barbara Beeton       | _Initial content discussions_ |
 | Denis Bitouzé        | _Improvements to lists description_ |
 | David Carlisle       | _Initial content discussions, editor and server integration_ |
@@ -19,6 +20,7 @@ The following people have made contributions to learnlatex.org:
 | Jim Hefferon         | _Initial content discussions_ |
 | Jonas Jaceck         | _Website design and implementation_ |
 | Jérémy Just          | _French translation_ |
+| Valentinas Kriaučiukas | _Lithuanian translation_ |
 | Marcel Fabian Krüger | _Initial content discussions_ |
 | Frank Mittelbach     | _Initial content discussions_ |
 | Phelype Oleinik      | _Portuguese translation_ |
@@ -26,8 +28,11 @@ The following people have made contributions to learnlatex.org:
 | Martin Sievers       | _German translation_ |
 | Jonathan P. Spratte  | _Initial content discussions, tables lesson, German translation_ |
 | Fernando S. Delgado Trujillo | _Spanish translation_ |
+| Vivek Tripathi       | _Hindi translation_ |
 | Moritz Wemheuer      | _Bibtex and Biblatex documentation _ |
 | Joseph Wright        | _Initial concept, Project lead_ |
 | Dung Vu              | _Vietnamese translation_ |
+| Daniel Zhang         | _Chinese translations_ (×2) |
 | Uwe Ziegenhagen      | _Initial content discussions_ |
-| निरंजन                 | _Marathi translation_ |
+| निरंजन                | _Marathi translation_ |
+| `@Gordon-72`         | _Italian translation_ |

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -7,23 +7,27 @@ permalink: /AUTHORS
 
 The following people have made contributions to learnlatex.org:
 
-- Barbara Beeton
-- Denis Bitouzé
-- David Carlisle
-- Paulo Roberto Massa Cereda
-- Joan Quintana Compte
-- Ulrike Fischer
-- Jim Hefferon
-- Jérémy Just
-- Marcel Fabian Krüger
-- Frank Mittelbach
-- Phelype Oleinik
-- Will Robertson
-- Jonathan P. Spratte
-- Fernando S. Delgado Trujillo
-- Moritz Wemheuer
-- Joseph Wright
-- Dung Vu
-- Uwe Ziegenhagen
-- निरंजन
-
+ 
+| Name                 | Role |
+|---                   |---|
+| Barbara Beeton       | _Initial content discussions_ |
+| Denis Bitouzé        | _Improvements to lists description_ |
+| David Carlisle       | _Initial content discussions, editor and server integration_ |
+| Paulo Roberto Massa Cereda | _Initial content discussions_ |
+| Joan Quintana Compte | _Catalan translation_ |
+| Ulrike Fischer       | _Initial content discussions_ |
+| Jim Hefferon         | _Initial content discussions_ |
+| Jonas Jaceck         | _Website design and implementation_ |
+| Jérémy Just          | _French translation_ |
+| Marcel Fabian Krüger | _Initial content discussions_ |
+| Frank Mittelbach     | _Initial content discussions_ |
+| Phelype Oleinik      | _Portuguese translation_ |
+| Will Robertson       | _Initial content discussions_ |
+| Martin Sievers       | _German translation_ |
+| Jonathan P. Spratte  | _Initial content discussions, tables lesson, German translation_ |
+| Fernando S. Delgado Trujillo | _Spanish translation_ |
+| Moritz Wemheuer      | _Bibtex and Biblatex documentation _ |
+| Joseph Wright        | _Initial concept, Project lead_ |
+| Dung Vu              | _Vietnamese translation_ |
+| Uwe Ziegenhagen      | _Initial content discussions_ |
+| निरंजन                 | _Marathi translation_ |


### PR DESCRIPTION
While reviewing open issues I noticed this old branch suggesting a tabular layout for the author list which is mentioned in #189 

If we don't adopt the table here we should update the list in the main branch anyway with newer translators. (matching the additions on the last commit in the author-roles branch). 

A note on names, if "Real names" are available from github profiles I have used them, if not I haven't shown them.
