### PR TITLE
Where straightforward, added a version for LuaLaTeX (with babel).

### DIFF
--- a/ca/language-01.md
+++ b/ca/language-01.md
@@ -25,6 +25,15 @@ LaTeX es va escriure pensant en l'idioma anglès, i per tant hi ha molts pocs as
 El text.
 \end{document}
 ```
+Amb LuaLaTeX:
+```latex
+%!TeX lualatex
+\documentclass{article}
+\usepackage[catalan]{babel}
+\begin{document}
+El text.
+\end{document}
+```
 
 El paquet `babel` es cuida de modificar el que calgui per tal de respectar les normes tipogràfiques de la llengua que volgueu, especialment:
 * El guionatge dels mots als finals de línia (anomenats "patrons de guionatge");

--- a/en/language-01.md
+++ b/en/language-01.md
@@ -28,3 +28,13 @@ using US English patterns, but you can switch to UK ones using `babel`.
 Some text
 \end{document}
 ```
+With LuaLaTeX:
+```latex
+%!TeX lualatex
+\documentclass{article}
+\usepackage[british]{babel}
+\begin{document}
+Some text
+\end{document}
+```
+

--- a/es/language-01.md
+++ b/es/language-01.md
@@ -30,6 +30,16 @@ Todo ello puede, solucionarse fácilmente utilizando el paquete babel:
 Some text
 \end{document}
 ```
+Con LuaLaTeX:
+```latex
+%!TeX lualatex
+\documentclass{article}
+\usepackage[spanish]{babel}
+\begin{document}
+Some text
+\end{document}
+```
+
 
 Puede igualmente utilizarlo de la forma siguiente:
 

--- a/fr/language-01.md
+++ b/fr/language-01.md
@@ -33,6 +33,17 @@ vous utilisez (éventuellement plusieurs séparés par des virgules):
 Du texte.
 \end{document}
 ```
+Avec LuaLaTeX:
+```latex
+%!TeX lualatex
+\documentclass{article}
+
+\usepackage[french]{babel}
+
+\begin{document}
+Du texte.
+\end{document}
+```
 
 `Babel` s'occupe de modifier pour vous tout ce qu'il faut pour respecter
 les règles typographiques de la langue que vous lui demandez, notamment :

--- a/it/language-01.md
+++ b/it/language-01.md
@@ -37,3 +37,16 @@ Un po' di testo in italiano.
 
 \end{document}
 ```
+
+Con LuaLaTeX:
+```latex
+%!TeX lualatex
+\documentclass{article}
+\usepackage[italian]{babel} % qui si dichiara la lingua del documento
+
+\begin{document}
+
+Un po' di testo in italiano.
+
+\end{document}
+```

--- a/pt/language-01.md
+++ b/pt/language-01.md
@@ -33,6 +33,15 @@ respectivamente:
 \chapter{Viu? :)}
 \end{document}
 ```
+Com LuaLaTeX:
+```latex
+%!TeX lualatex
+\documentclass{book}
+\usepackage[brazilian]{babel}
+\begin{document}
+\chapter{Viu? :)}
+\end{document}
+```
 
 Ambas as opções carregam os padrões de hifenização da língua portuguesa, e
 modificam os textos localizados de acordo (há pequenas diferenças nesses textos


### PR DESCRIPTION
LuaLaTeX is the preferred engine, but many examples are still based on pdfLaTeX, with `fontenc`.