### PR TITLE
fix: correct inplementation->implementation typo in more-16.md

### DIFF
--- a/en/more-16.md
+++ b/en/more-16.md
@@ -10,7 +10,7 @@ toc-anchor-text: "More on: Accessing documentation and getting help"
 ## Documented sources of LaTeX
 
 The `texdoc` command described earlier is not restricted to package documentation. If you wish to
-go beyond the areas covered by this course and study the LaTeX inplementation in detail then
+go beyond the areas covered by this course and study the LaTeX implementation in detail then
 the following links may help.
 
 The source of LaTeX itself is available as a LaTeX-typeset document `source2e.pdf`, available

--- a/tr/more-16.md
+++ b/tr/more-16.md
@@ -10,7 +10,7 @@ toc-anchor-text: "More on: Accessing documentation and getting help"
 ## Documented sources of LaTeX
 
 The `texdoc` command described earlier is not restricted to package documentation. If you wish to
-go beyond the areas covered by this course and study the LaTeX inplementation in detail then
+go beyond the areas covered by this course and study the LaTeX implementation in detail then
 the following links may help.
 
 The source of LaTeX itself is available as a LaTeX-typeset document `source2e.pdf`, available


### PR DESCRIPTION
Fix typo in English (en/more-16.md:13) and Turkish (tr/more-16.md:13):

- `inplementation` → `implementation`
- Same typo appears in both language versions

2 files, 2 lines, 1 commit.